### PR TITLE
Add basic training module

### DIFF
--- a/migrations/20240520_create_training_tables.sql
+++ b/migrations/20240520_create_training_tables.sql
@@ -1,0 +1,24 @@
+-- Create training sessions table
+CREATE TABLE IF NOT EXISTS training_sessions (
+    id SERIAL PRIMARY KEY,
+    employee_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    start_date DATE NOT NULL,
+    end_date DATE,
+    location TEXT,
+    trainer TEXT,
+    created_by_user_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_training_employee ON training_sessions(employee_id);
+CREATE INDEX IF NOT EXISTS idx_training_start_date ON training_sessions(start_date);
+CREATE INDEX IF NOT EXISTS idx_training_end_date ON training_sessions(end_date);
+
+-- Trigger to update updated_at column
+CREATE TRIGGER update_training_sessions_updated_at
+    BEFORE UPDATE ON training_sessions
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/src/pages/api/training.ts
+++ b/src/pages/api/training.ts
@@ -1,0 +1,62 @@
+import { Pool } from 'pg';
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const { employeeId } = req.query;
+    try {
+      let query = 'SELECT * FROM training_sessions ORDER BY start_date DESC';
+      let values: any[] = [];
+      if (employeeId) {
+        query = 'SELECT * FROM training_sessions WHERE employee_id = $1 ORDER BY start_date DESC';
+        values = [employeeId];
+      }
+      const result = await pool.query(query, values);
+      return res.status(200).json(result.rows);
+    } catch (error) {
+      console.error('Error fetching training sessions:', error);
+      return res.status(500).json({ message: 'Failed to fetch training sessions', error: error.message });
+    }
+  } else if (req.method === 'POST') {
+    const {
+      employee_id,
+      title,
+      description,
+      start_date,
+      end_date,
+      location,
+      trainer,
+      created_by_user_id,
+    } = req.body;
+
+    if (!employee_id || !title || !start_date || !created_by_user_id) {
+      return res.status(400).json({ message: 'Required fields missing' });
+    }
+
+    try {
+      const query = `INSERT INTO training_sessions (employee_id, title, description, start_date, end_date, location, trainer, created_by_user_id)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *`;
+      const values = [
+        employee_id,
+        title,
+        description || null,
+        start_date,
+        end_date || null,
+        location || null,
+        trainer || null,
+        created_by_user_id,
+      ];
+      const result = await pool.query(query, values);
+      return res.status(201).json(result.rows[0]);
+    } catch (error) {
+      console.error('Error creating training session:', error);
+      return res.status(500).json({ message: 'Failed to create training session', error: error.message });
+    }
+  } else {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+}

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -22,7 +22,7 @@ const modules = [
   { name: 'Dossiers de Colaboradores', description: 'Dados, ausências, funções', icon: '📁', path: '#' }, // Example placeholder path
   { name: 'Candidaturas e Vagas', description: 'Vagas, triagem, entrevistas', icon: '📄', path: '/recruitmentdashboard' },
   { name: 'Integração de Novos Colaboradores', description: 'Checklists, feedback', icon: '🚀', path: '#' },
-  { name: 'Formação & Certificação', description: 'Planos, necessidades, certificados', icon: '🎓', path: '#' },
+  { name: 'Formação & Certificação', description: 'Planos, necessidades, certificados', icon: '🎓', path: '/training' },
   { name: 'Desempenho & Feedback', description: 'Avaliações periódicas, autoavaliações', icon: '📊', path: '/evaluation' },
   { name: 'Clima & Saída de Colaboradores', description: 'Satisfação, saída', icon: '😊', path: '#' },
   { name: 'Promoções e Transferências', description: 'Mobilidade interna', icon: '🧭', path: '#' },

--- a/src/pages/training.tsx
+++ b/src/pages/training.tsx
@@ -1,0 +1,111 @@
+import { useState, useEffect, FormEvent } from 'react';
+import { useSelectedEmployee } from '@/contexts/SelectedEmployeeContext';
+
+interface TrainingSession {
+  id: number;
+  employee_id: string;
+  title: string;
+  description: string | null;
+  start_date: string;
+  end_date: string | null;
+  location: string | null;
+  trainer: string | null;
+}
+
+export default function TrainingPage() {
+  const { selectedEmployeeId, systemUserId } = useSelectedEmployee();
+  const [sessions, setSessions] = useState<TrainingSession[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    start_date: '',
+    end_date: '',
+    location: '',
+    trainer: '',
+  });
+
+  useEffect(() => {
+    if (selectedEmployeeId) {
+      fetchSessions();
+    }
+  }, [selectedEmployeeId]);
+
+  const fetchSessions = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/training?employeeId=${selectedEmployeeId}`);
+      const data = await res.json();
+      setSessions(data);
+    } catch (err) {
+      console.error('Failed to fetch training sessions', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!selectedEmployeeId || !systemUserId) return;
+    const payload = {
+      employee_id: selectedEmployeeId,
+      title: form.title,
+      description: form.description || null,
+      start_date: form.start_date,
+      end_date: form.end_date || null,
+      location: form.location || null,
+      trainer: form.trainer || null,
+      created_by_user_id: systemUserId,
+    };
+    try {
+      const res = await fetch('/api/training', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        setForm({ title: '', description: '', start_date: '', end_date: '', location: '', trainer: '' });
+        fetchSessions();
+      }
+    } catch (err) {
+      console.error('Failed to create training session', err);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Formação</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input name="title" value={form.title} onChange={handleChange} placeholder="Título" className="border p-2 w-full" required />
+        <textarea name="description" value={form.description} onChange={handleChange} placeholder="Descrição" className="border p-2 w-full" />
+        <div className="flex space-x-2">
+          <input type="date" name="start_date" value={form.start_date} onChange={handleChange} className="border p-2 flex-1" required />
+          <input type="date" name="end_date" value={form.end_date} onChange={handleChange} className="border p-2 flex-1" />
+        </div>
+        <input name="location" value={form.location} onChange={handleChange} placeholder="Local" className="border p-2 w-full" />
+        <input name="trainer" value={form.trainer} onChange={handleChange} placeholder="Formador" className="border p-2 w-full" />
+        <button type="submit" className="bg-black text-white px-4 py-2">Guardar</button>
+      </form>
+
+      <h2 className="text-xl font-semibold mt-8">Ações de Formação</h2>
+      {loading ? (
+        <p>A carregar...</p>
+      ) : (
+        <ul className="space-y-2 mt-2">
+          {sessions.map(s => (
+            <li key={s.id} className="border p-2 rounded">
+              <p className="font-medium">{s.title} ({s.start_date})</p>
+              {s.trainer && <p className="text-sm text-gray-500">{s.trainer}</p>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SQL table for training sessions
- add API route for training CRUD
- add training page with form and list
- link training module from landing page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fa8612f48332807523c52cb1b420