### PR TITLE
Add global layout with employee dropdown

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { useSelectedEmployee } from '@/contexts/SelectedEmployeeContext';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import Header from './Header';
+
+interface Employee {
+  employee_number: number;
+  Name: string;
+}
+
+const AppLayout: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
+  const {
+    accounts,
+    selectedEmployeeId,
+    setSelectedEmployeeId,
+    setEmployeeProfileName,
+  } = useSelectedEmployee();
+
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [showSelectModal, setShowSelectModal] = useState(false);
+
+  useEffect(() => {
+    const loadEmployees = async () => {
+      if (!accounts || accounts.length === 0) return;
+      setLoading(true);
+      try {
+        const userId = accounts[0].username;
+        const res = await fetch(`/api/employee?userId=${userId}`);
+        if (res.ok) {
+          const data: Employee[] = await res.json();
+          setEmployees(data);
+          if (!selectedEmployeeId) {
+            if (data.length === 1) {
+              setSelectedEmployeeId(String(data[0].employee_number));
+              setEmployeeProfileName(data[0].Name);
+            } else if (data.length > 1) {
+              setShowSelectModal(true);
+            }
+          }
+        } else {
+          console.error('Failed to fetch employees');
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadEmployees();
+  }, [accounts, selectedEmployeeId, setSelectedEmployeeId, setEmployeeProfileName]);
+
+  const handleSelectByIndex = (idx: number) => {
+    const emp = employees[idx];
+    if (emp) {
+      setSelectedEmployeeId(String(emp.employee_number));
+      setEmployeeProfileName(emp.Name);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const idx = parseInt(e.target.value, 10);
+    handleSelectByIndex(idx);
+    setShowSelectModal(false);
+  };
+
+  return (
+    <>
+      <Header employees={employees} onChange={handleSelectByIndex} loading={loading} />
+      <div className="p-4">
+        {children}
+      </div>
+      <Dialog open={showSelectModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Selecionar colaborador</DialogTitle>
+          </DialogHeader>
+          {loading ? (
+            <p>A carregar...</p>
+          ) : (
+            <select className="border p-2" onChange={handleChange} defaultValue="">
+              <option value="" disabled>
+                -- Escolha o colaborador --
+              </option>
+              {employees.map((emp, idx) => (
+                <option key={emp.employee_number} value={idx}>
+                  {emp.Name}
+                </option>
+              ))}
+            </select>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default AppLayout;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,9 +2,20 @@ import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import NotificationBell from '../evaluation/NotificationBell';
+import { useSelectedEmployee } from '@/contexts/SelectedEmployeeContext';
 
-export default function Header() {
+interface HeaderProps {
+  employees: { employee_number: number; Name: string }[];
+  onChange: (index: number) => void;
+  loading: boolean;
+}
+
+export default function Header({ employees, onChange, loading }: HeaderProps) {
   const router = useRouter();
+  const {
+    employeeProfileName,
+    selectedEmployeeId,
+  } = useSelectedEmployee();
 
   return (
     <header className="bg-white shadow">
@@ -49,7 +60,26 @@ export default function Header() {
               </Link>
             </div>
           </div>
-          <div className="flex items-center">
+          <div className="flex items-center space-x-4">
+            {selectedEmployeeId && (
+              <span className="text-sm text-gray-700">
+                {employeeProfileName}
+              </span>
+            )}
+            {employees.length > 0 && (
+              <select
+                className="border border-gray-300 rounded px-2 py-1 text-sm"
+                onChange={(e) => onChange(parseInt(e.target.value, 10))}
+                value={employees.findIndex(e => String(e.employee_number) === selectedEmployeeId)}
+              >
+                {employees.map((emp, idx) => (
+                  <option key={emp.employee_number} value={idx}>
+                    {emp.Name}
+                  </option>
+                ))}
+              </select>
+            )}
+            {loading && <span className="text-sm text-gray-500">A carregar...</span>}
             <NotificationBell />
           </div>
         </div>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { SelectedEmployeeProvider } from "@/contexts/SelectedEmployeeContext";
 import type { AppProps } from 'next/app';
 import 'react-toastify/dist/ReactToastify.css';
 import { ToastContainer } from 'react-toastify';
+import AppLayout from '@/components/layout/AppLayout';
 
 const msalInstance = new PublicClientApplication(msalConfig);
 
@@ -15,8 +16,10 @@ function MyApp({ Component, pageProps }: AppProps) {
     <MsalProvider instance={msalInstance}>
       <SelectedEmployeeProvider>
         <FuncionarioProvider>
-          <Component {...pageProps} />
-          <ToastContainer 
+          <AppLayout>
+            <Component {...pageProps} />
+          </AppLayout>
+          <ToastContainer
             position="top-right"
             autoClose={5000}
             hideProgressBar={false}


### PR DESCRIPTION
## Summary
- add `AppLayout` component that fetches employees
- update header to show selected employee with a dropdown
- wrap all pages with the new layout

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: property 'variant' does not exist)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686663b8b6dc8332a5ae7767615d429e