### PR TITLE
Clean MSAL config and document tutorial

### DIFF
--- a/docs/msal-tutorial.md
+++ b/docs/msal-tutorial.md
@@ -1,3 +1,8 @@
+# MSAL Tutorial
+
+The following guide was extracted from `src/authConfig.js`.
+```javascript
+
 
 
     import { LogLevel } from "@azure/msal-browser";
@@ -397,5 +402,4 @@
     SQL_DATABASE="RFWebApp"
 
     # Opcional: Se o seu SQL Server requer SSL mas não tem um certificado confiável (apenas para desenvolvimento)
-    # NODE_TLS_REJECT_UNAUTHORIZED=0
-    
+```

--- a/src/config/authConfig.js
+++ b/src/config/authConfig.js
@@ -1,10 +1,5 @@
 import { LogLevel } from "@azure/msal-browser";
 
-// Temporary debugging logs
-console.log("DEBUG: Client ID:", process.env.NEXT_PUBLIC_AZURE_CLIENT_ID);
-console.log("DEBUG: Authority:", process.env.NEXT_PUBLIC_AZURE_AUTHORITY);
-console.log("DEBUG: Redirect URI:", process.env.NEXT_PUBLIC_REDIRECT_URI);
-
 export const msalConfig = {
     auth: {
         clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID,


### PR DESCRIPTION
## Summary
- move MSAL tutorial text to `docs/msal-tutorial.md`
- remove obsolete `src/authConfig.js`
- clean up `src/config/authConfig.js` so it only exports configuration

## Testing
- `npm install` *(fails: postinstall script error)*

------
https://chatgpt.com/codex/tasks/task_e_686663bb563c8332941675ec405bfd1f