### PR TITLE
Add middleware for employee selection check

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl
+
+  if (pathname.startsWith('/api') || pathname.startsWith('/_next')) {
+    return NextResponse.next()
+  }
+
+  const selectedEmployeeId = req.cookies.get('selectedEmployeeId')?.value
+  if (selectedEmployeeId) {
+    return NextResponse.next()
+  }
+
+  if (!pathname.startsWith('/landing')) {
+    const url = req.nextUrl.clone()
+    url.pathname = '/landing'
+    return NextResponse.redirect(url)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)']
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -11,6 +11,8 @@ export interface AuthenticatedRequest extends NextApiRequest {
     roles: string[];
     account?: AccountInfo;
   };
+  /** The employee profile ID validated against the authenticated user */
+  selectedEmployeeId?: string;
 }
 
 // MSAL configuration
@@ -361,11 +363,12 @@ export function withAuth(handler: (req: AuthenticatedRequest, res: NextApiRespon
         console.log('[AuthMiddleware] Employee validation SUCCESSFUL.');
       }
 
-      // Attach user data to request
+      // Attach user data and selected employee to request
       req.user = {
         ...userData,
         account: await msalInstance.getActiveAccount(),
       };
+      req.selectedEmployeeId = selectedEmployeeId;
 
       // Call the handler
       await handler(req, res);


### PR DESCRIPTION
## Summary
- add a global middleware to redirect to `/landing` when `selectedEmployeeId` cookie is missing
- extend `AuthenticatedRequest` with `selectedEmployeeId`
- attach validated selected employee id in `withAuth` middleware

## Testing
- `npm install --ignore-scripts`
- `npm run lint` *(fails: asks for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686663ba4b7c8332bd67224cee4a6023