### PR TITLE
Remove placeholder user IDs

### DIFF
--- a/src/pages/api/evaluation-matrices/[matrixId]/applicability.ts
+++ b/src/pages/api/evaluation-matrices/[matrixId]/applicability.ts
@@ -7,9 +7,25 @@ const pool = new Pool({
 });
 
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  console.warn('Using placeholder system user ID for audit logs in matrix applicability API. Integrate actual authentication.');
-  return 'system-placeholder-user-id';
+  const authHeader = req.headers.authorization;
+
+  // If the handler is wrapped with withAuth the user object will be present
+  const user = (req as any).user;
+  if (user && typeof user.id === 'string') {
+    return user.id;
+  }
+
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
+    } catch (err) {
+      console.error('Failed to decode authorization token', err);
+    }
+  }
+
+  return null;
 }
 
 async function getSelectedEmployeeId(req: NextApiRequest): Promise<string | null> {

--- a/src/pages/api/evaluation-matrices/[matrixId]/criteria.ts
+++ b/src/pages/api/evaluation-matrices/[matrixId]/criteria.ts
@@ -7,9 +7,24 @@ const pool = new Pool({
 });
 
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  console.warn('Using placeholder system user ID for audit logs in matrix criteria API. Integrate actual authentication.');
-  return 'system-placeholder-user-id';
+  const authHeader = req.headers.authorization;
+
+  const user = (req as any).user;
+  if (user && typeof user.id === 'string') {
+    return user.id;
+  }
+
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
+    } catch (err) {
+      console.error('Failed to decode authorization token', err);
+    }
+  }
+
+  return null;
 }
 
 async function getSelectedEmployeeId(req: NextApiRequest): Promise<string | null> {

--- a/src/pages/api/evaluation-matrices/index.ts
+++ b/src/pages/api/evaluation-matrices/index.ts
@@ -33,9 +33,24 @@ async function setUserForSession(client, userId) {
 // }
 
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  console.warn('Using placeholder system user ID for audit logs in evaluation matrices API. Integrate actual authentication.');
-  return 'system-placeholder-user-id';
+  const authHeader = req.headers.authorization;
+
+  const user = (req as any).user;
+  if (user && typeof user.id === 'string') {
+    return user.id;
+  }
+
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
+    } catch (err) {
+      console.error('Failed to decode authorization token', err);
+    }
+  }
+
+  return null;
 }
 
 async function getSelectedEmployeeId(req: NextApiRequest): Promise<string | null> {

--- a/src/pages/api/evaluation/criteria/[criterionId].ts
+++ b/src/pages/api/evaluation/criteria/[criterionId].ts
@@ -11,10 +11,23 @@ const pool = new Pool({
 
 // Helper to get authenticated user ID (replace with your actual auth logic)
 async function getAuthenticatedSystemUserId(req: AuthenticatedRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  // This ID is the system-wide user identifier, used for audit trails (e.g., created_by_user_id)
-  console.warn('Using placeholder system user ID for audit logs in individual criterion API. Integrate actual authentication.');
-  return 'system-placeholder-user-id'; // Example: MSAL Object ID
+  const authHeader = req.headers.authorization;
+
+  if (req.user && typeof req.user.id === 'string') {
+    return req.user.id;
+  }
+
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
+    } catch (err) {
+      console.error('Failed to decode authorization token', err);
+    }
+  }
+
+  return null;
 }
 
 // Helper to get the selected Employee ID (e.g., from a custom header or session)

--- a/src/pages/api/evaluation/matrices/[matrixId].ts
+++ b/src/pages/api/evaluation/matrices/[matrixId].ts
@@ -11,9 +11,24 @@ const pool = new Pool({
 
 // Helper to get authenticated user ID
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  console.warn('Using placeholder system user ID for audit logs in matrices API. Integrate actual authentication.');
-  return 'system-placeholder-user-id';
+  const authHeader = req.headers.authorization;
+
+  const user = (req as any).user;
+  if (user && typeof user.id === 'string') {
+    return user.id;
+  }
+
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
+    } catch (err) {
+      console.error('Failed to decode authorization token', err);
+    }
+  }
+
+  return null;
 }
 
 // Helper to get the selected Employee ID

--- a/src/pages/api/evaluation/matrices/[matrixId]/applicability.ts
+++ b/src/pages/api/evaluation/matrices/[matrixId]/applicability.ts
@@ -10,9 +10,24 @@ const pool = new Pool({
 
 // Helper to get authenticated user ID
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  console.warn('Using placeholder system user ID for audit logs in matrices API. Integrate actual authentication.');
-  return 'system-placeholder-user-id';
+  const authHeader = req.headers.authorization;
+
+  const user = (req as any).user;
+  if (user && typeof user.id === 'string') {
+    return user.id;
+  }
+
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
+    } catch (err) {
+      console.error('Failed to decode authorization token', err);
+    }
+  }
+
+  return null;
 }
 
 // Helper to get the selected Employee ID

--- a/src/pages/api/evaluation/matrices/[matrixId]/criteria.ts
+++ b/src/pages/api/evaluation/matrices/[matrixId]/criteria.ts
@@ -9,9 +9,24 @@ const pool = new Pool({
 
 // Renamed: Helper to get the actual logged-in system user ID (e.g., from MSAL)
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with your ACTUAL MSAL token validation and user ID extraction.
-  console.warn('MATRIX_CRITERIA_API: Using placeholder system User ID. Integrate actual MSAL authentication.');
-  return 'logged-in-system-user-via-msal'; 
+  const authHeader = req.headers.authorization;
+
+  const user = (req as any).user;
+  if (user && typeof user.id === 'string') {
+    return user.id;
+  }
+
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
+    } catch (err) {
+      console.error('Failed to decode authorization token', err);
+    }
+  }
+
+  return null;
 }
 
 // Helper to get the Employee ID the user is currently acting as (selected on landing)

--- a/src/pages/api/evaluation/matrices/index.ts
+++ b/src/pages/api/evaluation/matrices/index.ts
@@ -10,9 +10,24 @@ const pool = new Pool({
 
 // Helper to get authenticated user ID
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  console.warn('Using placeholder system user ID for audit logs in matrices API. Integrate actual authentication.');
-  return 'system-placeholder-user-id';
+  const authHeader = req.headers.authorization;
+
+  const user = (req as any).user;
+  if (user && typeof user.id === 'string') {
+    return user.id;
+  }
+
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
+    } catch (err) {
+      console.error('Failed to decode authorization token', err);
+    }
+  }
+
+  return null;
 }
 
 // Helper to get the selected Employee ID

--- a/src/pages/api/evaluation/self-evaluations.ts
+++ b/src/pages/api/evaluation/self-evaluations.ts
@@ -13,9 +13,24 @@ const pool = new Pool({
 
 // Helper to get authenticated user ID (replace with your actual auth logic)
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  console.warn('Using placeholder system user ID for audit logs in self-evaluations API. Integrate actual authentication.');
-  return 'system-placeholder-user-id'; // Example: MSAL Object ID
+  const authHeader = req.headers.authorization;
+
+  const user = (req as any).user;
+  if (user && typeof user.id === 'string') {
+    return user.id;
+  }
+
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
+    } catch (err) {
+      console.error('Failed to decode authorization token', err);
+    }
+  }
+
+  return null;
 }
 
 // Helper to get the selected Employee ID (e.g., from a custom header or session)


### PR DESCRIPTION
## Summary
- replace placeholder user ID logic with real token parsing
- drop warning messages about placeholder user IDs

## Testing
- `npx next lint` *(fails: needs packages)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686667f271748332a4f64662c4d8bdf6