### PR TITLE
refactor: use shared db pool across evaluation APIs

### DIFF
--- a/src/pages/api/evaluation/matrix/apply.ts
+++ b/src/pages/api/evaluation/matrix/apply.ts
@@ -1,11 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
 import { getSession } from 'next-auth/react';
-
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
+import { pool } from '../../../../lib/db/pool';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {

--- a/src/pages/api/evaluation/notifications/index.ts
+++ b/src/pages/api/evaluation/notifications/index.ts
@@ -1,12 +1,7 @@
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../middleware/auth';
 import { isAdmin } from '../../../../lib/auth';
-import { Pool } from 'pg';
-
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
+import { pool } from '../../../../lib/db/pool';
 
 async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise<void> {
   if (!req.user) {

--- a/src/pages/api/evaluation/self-evaluations.ts
+++ b/src/pages/api/evaluation/self-evaluations.ts
@@ -1,15 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
 import { withAuth, AuthenticatedRequest, getUserManager } from '../../../middleware/auth';
 import { withErrorHandler, ValidationError, NotFoundError, AuthorizationError } from '../../../lib/errors';
-import { executeQuery, executeTransaction } from '../../../lib/db/pool';
+import { pool, executeQuery, executeTransaction } from '../../../lib/db/pool';
 import { z } from 'zod';
 
-// TODO: Ideally, use a shared DB pool module
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false }, // Adjust based on your DB hosting requirements
-});
+// Using shared database pool instance from lib/db/pool
 
 // Helper to get authenticated user ID (replace with your actual auth logic)
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {


### PR DESCRIPTION
## Summary
- reuse pool instance across evaluation APIs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668d831b248332b925bd393b2793c8