### PR TITLE
Fix employee join in matrix applicability API

### DIFF
--- a/src/pages/api/evaluation-matrix/applicability/[matrixId].ts
+++ b/src/pages/api/evaluation-matrix/applicability/[matrixId].ts
@@ -21,9 +21,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const result = await client.query(
-      `SELECT e.id, e.name, e.email, e.position, e.department
+      `SELECT e.employee_number, e.name, e.email, e.position, e.department
        FROM employees e
-       INNER JOIN evaluation_matrix_applicability ema ON e.id = ema.employee_id
+       INNER JOIN evaluation_matrix_applicability ema ON e.employee_number = ema.employee_id
        WHERE ema.matrix_id = $1
        ORDER BY e.name`,
       [matrixId]


### PR DESCRIPTION
## Summary
- reference correct employee PK when listing applicability

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668d811cec83328b5262e4378baa1e