### PR TITLE
Use fetchWithAuth helper

### DIFF
--- a/src/components/evaluation/NotificationBell.tsx
+++ b/src/components/evaluation/NotificationBell.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { BellIcon } from '@heroicons/react/24/outline';
 import { useRouter } from 'next/router';
+import { fetchWithAuth, ApiClientOptions } from '@/lib/apiClient';
+import { useSelectedEmployee } from '@/contexts/SelectedEmployeeContext';
 
 interface Notification {
   id: number;
@@ -21,6 +23,7 @@ export default function NotificationBell() {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
+  const { msalInstance, accounts, inProgress, selectedEmployeeId } = useSelectedEmployee();
 
   useEffect(() => {
     if (isOpen) {
@@ -31,11 +34,18 @@ export default function NotificationBell() {
   const fetchNotifications = async () => {
     try {
       setIsLoading(true);
-      const response = await fetch('/api/evaluation/notifications');
-      if (!response.ok) {
-        throw new Error('Failed to fetch notifications');
-      }
-      const data = await response.json();
+      const apiClientOptions: ApiClientOptions = {
+        msalInstance: msalInstance!,
+        selectedEmployeeId,
+        interactionStatus: inProgress,
+        activeAccount: accounts[0] || null,
+      };
+
+      const data = await fetchWithAuth<Notification[]>(
+        '/api/evaluation/notifications',
+        { method: 'GET' },
+        apiClientOptions
+      );
       setNotifications(data);
     } catch (error) {
       console.error('Error fetching notifications:', error);
@@ -47,13 +57,20 @@ export default function NotificationBell() {
   const handleNotificationClick = async (notification: Notification) => {
     try {
       // Mark notification as read
-      await fetch('/api/evaluation/notifications', {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
+      const apiClientOptions: ApiClientOptions = {
+        msalInstance: msalInstance!,
+        selectedEmployeeId,
+        interactionStatus: inProgress,
+        activeAccount: accounts[0] || null,
+      };
+      await fetchWithAuth(
+        '/api/evaluation/notifications',
+        {
+          method: 'PUT',
+          body: JSON.stringify({ id: notification.id }),
         },
-        body: JSON.stringify({ id: notification.id }),
-      });
+        apiClientOptions
+      );
 
       // Navigate to the appropriate page based on notification type
       if (notification.metadata) {

--- a/src/pages/candidate-management/[requestId].tsx
+++ b/src/pages/candidate-management/[requestId].tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
-import { useMsal } from "@azure/msal-react";
+import { fetchWithAuth, ApiClientOptions } from "@/lib/apiClient";
+import { useSelectedEmployee } from "@/contexts/SelectedEmployeeContext";
 import gsap from "gsap";
 import { ArrowLeft, Briefcase, Users, Building2, FileText, CalendarDays, Info, ChevronDown, ChevronRight, PlusCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -118,7 +119,7 @@ export default function CandidateManagementPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const containerRef = useRef(null);
-  const { accounts } = useMsal();
+  const { msalInstance, accounts, inProgress, selectedEmployeeId } = useSelectedEmployee();
   const userName = accounts?.[0]?.name || 'Utilizador';
 
   const [hydrated, setHydrated] = useState(false);
@@ -165,12 +166,18 @@ export default function CandidateManagementPage() {
             'usergroups': JSON.stringify(user.idTokenClaims?.groups || []),
           };
 
-          const res = await fetch(`/api/recruitment?id=${requestId}`, { headers });
-          if (!res.ok) {
-            const errorData = await res.json().catch(() => ({ message: `Erro ${res.status}: ${res.statusText}` }));
-            throw new Error(errorData.message || 'Falha ao carregar detalhes do pedido');
-          }
-          const data = await res.json();
+          const apiClientOptions: ApiClientOptions = {
+            msalInstance: msalInstance!,
+            selectedEmployeeId,
+            interactionStatus: inProgress,
+            activeAccount: accounts[0] || null,
+          };
+
+          const data = await fetchWithAuth<Pedido>(
+            `/api/recruitment?id=${requestId}`,
+            { headers },
+            apiClientOptions
+          );
           setPedido(data);
         } catch (err: any) {
           setError(err.message);
@@ -216,12 +223,17 @@ export default function CandidateManagementPage() {
         'x-user-id': user?.localAccountId || user?.homeAccountId || 'unknown',
         'x-user-groups': JSON.stringify(user?.idTokenClaims?.groups || []),
       };
-      const res = await fetch(`/api/candidates?recruitment_id=${pedido.id}&stage=${stageId}`, { headers });
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => ({ message: `Erro ao buscar candidatos para ${stageId}` }));
-        throw new Error(errorData.message);
-      }
-      const data = await res.json();
+      const apiClientOptions: ApiClientOptions = {
+        msalInstance: msalInstance!,
+        selectedEmployeeId,
+        interactionStatus: inProgress,
+        activeAccount: accounts[0] || null,
+      };
+      const data = await fetchWithAuth<Candidate[]>(
+        `/api/candidates?recruitment_id=${pedido.id}&stage=${stageId}`,
+        { headers },
+        apiClientOptions
+      );
       setCandidatesByStage(prev => ({ ...prev, [stageId]: data }));
     } catch (err: any) {
       console.error(`Erro ao buscar candidatos para ${stageId}:`, err);
@@ -300,16 +312,22 @@ export default function CandidateManagementPage() {
         'x-user-groups': JSON.stringify(user?.idTokenClaims?.groups || []),
       };
 
-      const res = await fetch(`/api/candidates/${candidateId}`, {
-        method: 'PATCH',
-        headers,
-        body: JSON.stringify({ stage: newStage }),
-      });
+      const apiClientOptions: ApiClientOptions = {
+        msalInstance: msalInstance!,
+        selectedEmployeeId,
+        interactionStatus: inProgress,
+        activeAccount: accounts[0] || null,
+      };
 
-      if (!res.ok) {
-        const errorResult = await res.json().catch(() => ({ message: "Failed to update candidate stage on server." }));
-        throw new Error(errorResult.message);
-      }
+      await fetchWithAuth(
+        `/api/candidates/${candidateId}`,
+        {
+          method: 'PATCH',
+          headers,
+          body: JSON.stringify({ stage: newStage }),
+        },
+        apiClientOptions
+      );
       console.log(`Candidate ${candidateId} stage updated to ${newStage} on server.`);
       // Optionally, show a success toast or notification
     } catch (error: any) {
@@ -383,17 +401,25 @@ export default function CandidateManagementPage() {
         'x-user-name': user?.name || 'Unknown User',
         'x-user-groups': JSON.stringify(user?.idTokenClaims?.groups || []),
       };
+      const apiClientOptions: ApiClientOptions = {
+        msalInstance: msalInstance!,
+        selectedEmployeeId,
+        interactionStatus: inProgress,
+        activeAccount: accounts[0] || null,
+      };
 
-      const res = await fetch('/api/candidates', {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(payload),
-      });
+      const result = await fetchWithAuth<any>(
+        '/api/candidates',
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(payload),
+        },
+        apiClientOptions
+      );
 
-      const result = await res.json();
-
-      if (!res.ok) {
-        throw new Error(result.message || 'Falha ao adicionar candidato.');
+      if (!result) {
+        throw new Error('Falha ao adicionar candidato.');
       }
       setSubmissionStatus({ type: 'success', message: 'Candidato adicionado com sucesso!' });
       // Refresh candidate list for the stage
@@ -444,17 +470,25 @@ export default function CandidateManagementPage() {
         'x-user-name': user?.name || 'Unknown User',
         'x-user-groups': JSON.stringify(user?.idTokenClaims?.groups || []),
       };
+      const apiClientOptions: ApiClientOptions = {
+        msalInstance: msalInstance!,
+        selectedEmployeeId,
+        interactionStatus: inProgress,
+        activeAccount: accounts[0] || null,
+      };
 
-      const res = await fetch(`/api/candidates/${selectedCandidateForViewEdit.id}`, {
-        method: 'PATCH',
-        headers,
-        body: JSON.stringify(payload), // Send only the updatable fields
-      });
+      const result = await fetchWithAuth<any>(
+        `/api/candidates/${selectedCandidateForViewEdit.id}`,
+        {
+          method: 'PATCH',
+          headers,
+          body: JSON.stringify(payload),
+        },
+        apiClientOptions
+      );
 
-      const result = await res.json();
-
-      if (!res.ok) {
-        throw new Error(result.message || 'Falha ao atualizar candidato.');
+      if (!result) {
+        throw new Error('Falha ao atualizar candidato.');
       }
       setSubmissionStatus({ type: 'success', message: 'Candidato atualizado com sucesso!' });
       // Refresh candidate list for the stage


### PR DESCRIPTION
## Summary
- use `fetchWithAuth` in `NotificationBell`
- apply `fetchWithAuth` across the candidate management page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668d80404083329942b3e7741454c9