### PR TITLE
Replace console statements with logger

### DIFF
--- a/src/components/evaluation/MatrixForm.tsx
+++ b/src/components/evaluation/MatrixForm.tsx
@@ -3,6 +3,7 @@ import { useForm, useFieldArray, Controller, SubmitHandler } from 'react-hook-fo
 import { message } from 'antd';
 import { useSelectedEmployee } from '../../contexts/SelectedEmployeeContext';
 import { fetchWithAuth, type ApiClientOptions } from '../../lib/apiClient';
+import { logger } from '@/lib/logger';
 import { InteractionStatus } from '@azure/msal-browser';
 
 // Re-using types from matrices.tsx for now, ideally share them
@@ -122,17 +123,17 @@ const MatrixForm: React.FC<MatrixFormProps> = ({ matrix, onClose, onSave, subord
         );
         setSubordinatesWithActiveMatrix((data?.activeEmployeeIds || []).map(String));
       } catch (error) {
-        console.error('Erro ao verificar matrizes ativas:', error);
+        logger.error('Erro ao verificar matrizes ativas:', error);
       }
     };
     fetchActiveMatrixForSubs();
   }, [subordinatesList, msalInstance, activeAccount, interactionStatus, currentSelectedEmployeeId]);
 
   // Debug logs para garantir tipos corretos
-  console.log('subordinatesWithActiveMatrix:', subordinatesWithActiveMatrix);
-  console.log('typeof subordinatesWithActiveMatrix[0]:', typeof subordinatesWithActiveMatrix[0]);
-  console.log('subordinatesList ids:', subordinatesList?.map(s => s.id));
-  console.log('typeof subordinatesList[0].id:', typeof subordinatesList?.[0]?.id);
+  logger.log('subordinatesWithActiveMatrix:', subordinatesWithActiveMatrix);
+  logger.log('typeof subordinatesWithActiveMatrix[0]:', typeof subordinatesWithActiveMatrix[0]);
+  logger.log('subordinatesList ids:', subordinatesList?.map(s => s.id));
+  logger.log('typeof subordinatesList[0].id:', typeof subordinatesList?.[0]?.id);
 
   // Handle subordinate selection change for checkboxes
   const handleSubordinateSelection = (subordinateId: string | number) => {
@@ -189,7 +190,7 @@ const MatrixForm: React.FC<MatrixFormProps> = ({ matrix, onClose, onSave, subord
       // Error handling is done in handleSaveMatrix, which uses toast.error(err.message)
       // If MatrixForm needs its own specific error display beyond what onSave does, add it here.
       // For now, assume onSave's error handling is sufficient.
-      console.error("[MatrixForm] onSubmit: Error during onSave call:", error);
+      logger.error('[MatrixForm] onSubmit: Error during onSave call:', error);
       // message.error("Falha ao salvar a matriz a partir do formulário."); // Avoid double toasting if onSave also toasts
     }
   };

--- a/src/components/evaluation/NotificationBell.tsx
+++ b/src/components/evaluation/NotificationBell.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { BellIcon } from '@heroicons/react/24/outline';
 import { useRouter } from 'next/router';
+import { logger } from '@/lib/logger';
 
 interface Notification {
   id: number;
@@ -38,7 +39,7 @@ export default function NotificationBell() {
       const data = await response.json();
       setNotifications(data);
     } catch (error) {
-      console.error('Error fetching notifications:', error);
+      logger.error('Error fetching notifications:', error);
     } finally {
       setIsLoading(false);
     }
@@ -71,7 +72,7 @@ export default function NotificationBell() {
         n.id === notification.id ? { ...n, status: 'read' } : n
       ));
     } catch (error) {
-      console.error('Error handling notification click:', error);
+      logger.error('Error handling notification click:', error);
     }
   };
 

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelectedEmployee } from '@/contexts/SelectedEmployeeContext';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import Header from './Header';
+import { logger } from '@/lib/logger';
 
 interface Employee {
   employee_number: number;
@@ -39,10 +40,10 @@ const AppLayout: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
             }
           }
         } else {
-          console.error('Failed to fetch employees');
+          logger.error('Failed to fetch employees');
         }
       } catch (err) {
-        console.error(err);
+        logger.error(err);
       } finally {
         setLoading(false);
       }

--- a/src/config/authConfig.js
+++ b/src/config/authConfig.js
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { LogLevel } from "@azure/msal-browser";
 
 
@@ -21,7 +22,7 @@ export const msalConfig = {
                 }
                 switch (level) {
                     case LogLevel.Error:
-                        console.error(message);
+                        logger.error(message);
                         return;
                     case LogLevel.Info:
                         return;

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,5 @@
 import { IPublicClientApplication, InteractionRequiredAuthError, InteractionStatus, AccountInfo } from "@azure/msal-browser";
+import { logger } from '@/lib/logger';
 
 // This should match the API scopes defined in your MSAL configuration and frontend components.
 const apiScopes = [process.env.NEXT_PUBLIC_API_SCOPES || "api://YOUR_BACKEND_APP_ID_URI/.default"];
@@ -30,7 +31,7 @@ export async function fetchWithAuth<T = any>(
   const { msalInstance, interactionStatus, activeAccount, selectedEmployeeId } = options;
 
   if (!msalInstance || !activeAccount) {
-    console.error('[apiClient] MSAL instance or active account is missing. Cannot proceed with authenticated request.', { msalInstanceExists: !!msalInstance, activeAccountExists: !!activeAccount });
+    logger.error('[apiClient] MSAL instance or active account is missing. Cannot proceed with authenticated request.', { msalInstanceExists: !!msalInstance, activeAccountExists: !!activeAccount });
     // For GET requests, we might have previously allowed them to proceed,
     // but protected GET endpoints will fail. It's better to stop here.
     return Promise.reject(new Error('Authentication context not available.'));
@@ -43,13 +44,13 @@ export async function fetchWithAuth<T = any>(
 
   let tokenResponse;
 
-  console.log(`[apiClient] fetchWithAuth attempting for URL: ${apiUrl}, Method: ${requestOptions.method}`);
-  console.log('[apiClient] Options:', { interactionStatus, selectedEmployeeId, activeAccountUsername: activeAccount.username });
+  logger.log(`[apiClient] fetchWithAuth attempting for URL: ${apiUrl}, Method: ${requestOptions.method}`);
+  logger.log('[apiClient] Options:', { interactionStatus, selectedEmployeeId, activeAccountUsername: activeAccount.username });
 
   try {
     if (interactionStatus === InteractionStatus.None) {
       tokenResponse = await msalInstance.acquireTokenSilent(request);
-      console.log(`[apiClient] Token acquired silently for ${apiUrl}:`, tokenResponse ? 'Token obtained' : 'Token NOT obtained');
+      logger.log(`[apiClient] Token acquired silently for ${apiUrl}:`, tokenResponse ? 'Token obtained' : 'Token NOT obtained');
     } else {
       console.warn(`[apiClient] Interaction in progress (${interactionStatus}), skipping silent token acquisition for ${apiUrl}. This might lead to auth failure if a redirect/popup isn't completing.`);
       // Decide if we should attempt acquireTokenRedirect/Popup here or if the main app flow handles it.
@@ -57,9 +58,9 @@ export async function fetchWithAuth<T = any>(
       // This situation (interaction in progress) should ideally resolve before making API calls.
     }
   } catch (error) {
-    console.error(`[apiClient] Silent token acquisition failed for ${apiUrl}:`, error);
+    logger.error(`[apiClient] Silent token acquisition failed for ${apiUrl}:`, error);
     if (error instanceof InteractionRequiredAuthError) {
-      console.log(`[apiClient] Interaction required for ${apiUrl}. Depending on app flow, redirect/popup should be invoked.`);
+      logger.log(`[apiClient] Interaction required for ${apiUrl}. Depending on app flow, redirect/popup should be invoked.`);
       // msalInstance.acquireTokenRedirect(request); // Or acquireTokenPopup
       // For now, let API call fail to indicate an issue with interaction handling.
     }
@@ -80,7 +81,7 @@ export async function fetchWithAuth<T = any>(
 
   if (tokenResponse && tokenResponse.accessToken) {
     headers.append('Authorization', `Bearer ${tokenResponse.accessToken}`);
-    console.log(`[apiClient] Authorization header added for ${apiUrl}. Token snippet: ${tokenResponse.accessToken.substring(0, 20)}...`);
+    logger.log(`[apiClient] Authorization header added for ${apiUrl}. Token snippet: ${tokenResponse.accessToken.substring(0, 20)}...`);
   } else {
     console.warn(`[apiClient] No access token available for ${apiUrl}. Proceeding without Authorization header. This will likely fail for protected routes.`);
     // For GET requests, we used to let them pass, but now we are stricter.
@@ -88,7 +89,7 @@ export async function fetchWithAuth<T = any>(
     // this branch means the header isn't even being added.
   }
   
-  console.log(`[apiClient] Headers being sent for ${apiUrl}:`, Array.from(headers.entries()));
+  logger.log(`[apiClient] Headers being sent for ${apiUrl}:`, Array.from(headers.entries()));
 
   const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || ''; // e.g., http://localhost:3000
 
@@ -99,7 +100,7 @@ export async function fetchWithAuth<T = any>(
     });
 
     if (apiUrl.includes('activeMatrixCheck')) {
-      console.log(`[apiClient] Response status for activeMatrixCheck (${apiUrl}): ${response.status}`);
+      logger.log(`[apiClient] Response status for activeMatrixCheck (${apiUrl}): ${response.status}`);
     }
 
     if (!response.ok) {
@@ -130,7 +131,7 @@ export async function fetchWithAuth<T = any>(
     }
   } catch (error) {
     // Log network errors or errors during fetch/json parsing
-    console.error(`[apiClient] Fetch or JSON parsing error for ${apiUrl}:`, error);
+    logger.error(`[apiClient] Fetch or JSON parsing error for ${apiUrl}:`, error);
     // Re-throw the error so the calling function can handle it
     // If it's already our custom error object, just rethrow it.
     if (error && typeof error === 'object' && 'status' in error) throw error;
@@ -155,7 +156,7 @@ function MyComponent() {
 
   const handleFetchData = async () => {
     if (accounts.length === 0) {
-      console.error("No user signed in.");
+      logger.error("No user signed in.");
       // Potentially trigger login or show a message
       return;
     }
@@ -174,7 +175,7 @@ function MyComponent() {
         { method: "GET" }, 
         clientOptions
       );
-      console.log("Fetched data:", data);
+      logger.log("Fetched data:", data);
 
       // Example POST request
       // const postData = { name: "Test" };
@@ -186,13 +187,13 @@ function MyComponent() {
       //   },
       //   clientOptions
       // );
-      // console.log("POST response:", response);
+      // logger.log("POST response:", response);
 
     } catch (error: any) {
-      console.error("API call failed:", error);
+      logger.error("API call failed:", error);
       if (error instanceof InteractionRequiredAuthError) {
         // Handle interaction required error (e.g., by redirecting or showing a popup)
-        // instance.acquireTokenRedirect(tokenRequest).catch(console.error);
+        // instance.acquireTokenRedirect(tokenRequest).catch(logger.error);
       } else {
         // Handle other errors (e.g., display a notification to the user)
         // alert(`Error: ${error.message}`);

--- a/src/lib/azureGraphService.ts
+++ b/src/lib/azureGraphService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { cca, GRAPH_SCOPES } from './msalConfig'; // Import shared MSAL config
 
 export interface GraphUser {
@@ -13,7 +14,7 @@ export async function getGraphToken(): Promise<string | null> {
     const authResult = await cca.acquireTokenByClientCredential({ scopes: GRAPH_SCOPES });
     return authResult?.accessToken || null;
   } catch (error) {
-    console.error('Failed to acquire Graph token by client credential:', error);
+    logger.error('Failed to acquire Graph token by client credential:', error);
     return null;
   }
 }
@@ -26,7 +27,7 @@ export async function fetchFromGraph(graphToken: string, url: string): Promise<a
   if (!response.ok) {
     const errorText = await response.text();
     // Consider how to handle Graph API errors more gracefully or specifically if needed
-    console.error(`Graph API error: ${response.status} ${response.statusText} - ${errorText} for URL: ${url}`);
+    logger.error(`Graph API error: ${response.status} ${response.statusText} - ${errorText} for URL: ${url}`);
     throw new Error(`Graph API error: ${response.status} ${response.statusText}`);
   }
   try {
@@ -34,7 +35,7 @@ export async function fetchFromGraph(graphToken: string, url: string): Promise<a
   } catch (e) {
     // Handle cases where response might be ok but not JSON (e.g. 204 No Content for directReports if no one reports)
     if (response.status === 204) return { value: [] }; // Mimic Graph's empty value array for consistency
-    console.error('Failed to parse Graph API JSON response:', e);
+    logger.error('Failed to parse Graph API JSON response:', e);
     throw new Error('Failed to parse Graph API JSON response.');
   }
 }
@@ -48,7 +49,7 @@ export async function getDirectGraphSubordinates(userAzureAdId: string): Promise
   
   const graphToken = await getGraphToken();
   if (!graphToken) {
-    console.error('getDirectGraphSubordinates: Failed to get Graph token.');
+    logger.error('getDirectGraphSubordinates: Failed to get Graph token.');
     // Depending on desired error handling, you might throw here or return empty
     return []; 
   }
@@ -62,7 +63,7 @@ export async function getDirectGraphSubordinates(userAzureAdId: string): Promise
     return (graphSubordinatesData?.value as GraphUser[]) || [];
   } catch (error) {
     // Log the specific error from fetchFromGraph (which already logs details)
-    console.error(`getDirectGraphSubordinates: Error fetching direct reports for AAD user ${userAzureAdId}:`, error.message);
+    logger.error(`getDirectGraphSubordinates: Error fetching direct reports for AAD user ${userAzureAdId}:`, error.message);
     return []; // Return empty array on error to allow checks like .length > 0 to fail gracefully
   }
 }

--- a/src/lib/db/pool.ts
+++ b/src/lib/db/pool.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 
 if (!process.env.DATABASE_URL) {
@@ -20,7 +21,7 @@ export const pool = new Pool({
 
 // Handle pool errors
 pool.on('error', (err) => {
-  console.error('Unexpected error on idle client', err);
+  logger.error('Unexpected error on idle client', err);
   process.exit(-1);
 });
 
@@ -37,7 +38,7 @@ export async function executeQuery<T = any>(
     const result = await queryClient.query(query, params);
     return result.rows;
   } catch (error) {
-    console.error('Database query error:', error);
+    logger.error('Database query error:', error);
     throw error;
   } finally {
     if (shouldRelease) {

--- a/src/lib/employeeDbService.ts
+++ b/src/lib/employeeDbService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import sql from 'mssql';
 
 // Ensure these environment variables are set in your .env.local or environment
@@ -40,7 +41,7 @@ export async function getEmployeeUpnFromNumber(employeeNumber: string): Promise<
       return null;
     }
   } catch (dbError) {
-    console.error(`DB error in getEmployeeUpnFromNumber for employee number ${employeeNumber}:`, dbError);
+    logger.error(`DB error in getEmployeeUpnFromNumber for employee number ${employeeNumber}:`, dbError);
     return null; 
   } finally {
     if (pool) {
@@ -69,14 +70,14 @@ export async function getAzureADObjectIdFromUpn(upn: string): Promise<string | n
   if (!upn) return null;
   const graphToken = await getGraphToken();
   if (!graphToken) {
-    console.error('getAzureADObjectIdFromUpn: Failed to get graph token.');
+    logger.error('getAzureADObjectIdFromUpn: Failed to get graph token.');
     return null;
   }
   try {
     const graphUser = await fetchFromGraph(graphToken, `https://graph.microsoft.com/v1.0/users/${upn}?$select=id`);
     return graphUser?.id || null;
   } catch (error) {
-    console.error(`Error fetching AAD Object ID for UPN ${upn} from Graph:`, error);
+    logger.error(`Error fetching AAD Object ID for UPN ${upn} from Graph:`, error);
     return null;
   }
 }
@@ -91,7 +92,7 @@ export async function getAllActiveEmployees() {
     // Retorna um array de objetos { Number, CompanyName, Name }
     return result.recordset;
   } catch (dbError) {
-    console.error('DB error in getAllActiveEmployees:', dbError);
+    logger.error('DB error in getAllActiveEmployees:', dbError);
     return [];
   } finally {
     if (pool) {
@@ -132,7 +133,7 @@ export async function getEmployeeDetailsByUserId(userId: string) {
       `);
     return result.recordset[0];
   } catch (err) {
-    console.error('Error fetching employee data from SQL Server:', err);
+    logger.error('Error fetching employee data from SQL Server:', err);
     return null;
   }
 }
@@ -149,7 +150,7 @@ export async function getEmployeeDetailsByNumber(number: string) {
       `);
     return result.recordset[0];
   } catch (err) {
-    console.error('Error fetching employee data from SQL Server:', err);
+    logger.error('Error fetching employee data from SQL Server:', err);
     return null;
   }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiResponse } from 'next';
 
 // Custom error classes
@@ -56,7 +57,7 @@ export function sendError(res: NextApiResponse, error: Error | AppError) {
   }
 
   // Handle unexpected errors
-  console.error('Unexpected error:', error);
+  logger.error('Unexpected error:', error);
   return res.status(500).json({
     error: 'InternalServerError',
     code: 'INTERNAL_ERROR',

--- a/src/lib/evaluation/notificationService.ts
+++ b/src/lib/evaluation/notificationService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 
 const pool = new Pool({
@@ -142,7 +143,7 @@ export async function runNotificationChecks() {
   try {
     await checkAndCreateNotifications();
   } catch (error) {
-    console.error('Error in notification checks:', error);
+    logger.error('Error in notification checks:', error);
     throw error;
   }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,10 @@
+export const logger = {
+  log: (...args: unknown[]) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(...args);
+    }
+  },
+  error: (...args: unknown[]) => {
+    console.error(...args);
+  },
+};

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { InteractionRequiredAuthError } from '@azure/msal-browser';
 import { PublicClientApplication, AccountInfo } from '@azure/msal-browser';
@@ -52,7 +53,7 @@ function validateMsalConfig() {
     .map(([key]) => key);
 
   if (missingVars.length > 0) {
-    console.error('Missing required Azure AD configuration:', {
+    logger.error('Missing required Azure AD configuration:', {
       missing: missingVars,
       config: {
         ...requiredVars,
@@ -72,7 +73,7 @@ try {
   msalInstance = new PublicClientApplication(msalConfig);
   confidentialClient = new ConfidentialClientApplication(msalNodeConfig);
 } catch (error) {
-  console.error('Failed to initialize MSAL:', error);
+  logger.error('Failed to initialize MSAL:', error);
   throw error;
 }
 
@@ -106,7 +107,7 @@ async function getGraphApiToken(): Promise<string> {
 
     return result.accessToken;
   } catch (error) {
-    console.error('Error acquiring Graph API token:', error);
+    logger.error('Error acquiring Graph API token:', error);
     throw error;
   }
 }
@@ -123,7 +124,7 @@ async function validateUserToken(token: string): Promise<{ id: string; roles: st
     const userId = decodedToken.oid || decodedToken.sub;
 
     if (!userId) {
-      console.error('Could not extract user ID from token');
+      logger.error('Could not extract user ID from token');
       return null;
     }
 
@@ -137,7 +138,7 @@ async function validateUserToken(token: string): Promise<{ id: string; roles: st
 
     if (!response.ok) {
       const body = await response.text();
-      console.error('❌ Microsoft Graph API error:', {
+      logger.error('❌ Microsoft Graph API error:', {
         status: response.status,
         statusText: response.statusText,
         error: body,
@@ -148,7 +149,7 @@ async function validateUserToken(token: string): Promise<{ id: string; roles: st
     const user = await response.json();
 
     if (!user || !user.userPrincipalName) {
-      console.error('Could not extract userPrincipalName from Graph API response for user ID:', userId);
+      logger.error('Could not extract userPrincipalName from Graph API response for user ID:', userId);
       return null;
     }
 
@@ -178,7 +179,7 @@ async function validateUserToken(token: string): Promise<{ id: string; roles: st
       roles: roles
     };
   } catch (error) {
-    console.error('Token validation error:', {
+    logger.error('Token validation error:', {
       error: error instanceof Error ? error.message : 'Unknown error',
       stack: error instanceof Error ? error.stack : undefined
     });
@@ -196,7 +197,7 @@ export async function getUserManager(token: string): Promise<any> {
     const userId = decodedToken.oid || decodedToken.sub;
 
     if (!userId) {
-      console.error('Could not extract user ID from token');
+      logger.error('Could not extract user ID from token');
       return null;
     }
 
@@ -209,7 +210,7 @@ export async function getUserManager(token: string): Promise<any> {
 
     if (!response.ok) {
       const body = await response.text();
-      console.error('❌ Error fetching manager:', {
+      logger.error('❌ Error fetching manager:', {
         status: response.status,
         statusText: response.statusText,
         error: body,
@@ -219,7 +220,7 @@ export async function getUserManager(token: string): Promise<any> {
 
     return await response.json();
   } catch (error) {
-    console.error('Error fetching manager:', error);
+    logger.error('Error fetching manager:', error);
     return null;
   }
 }
@@ -238,7 +239,7 @@ export async function getUserDirectReports(token: string, userIdOrUpn?: string):
       const decodedUserToken = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       targetUserId = decodedUserToken.oid || decodedUserToken.sub;
       if (!targetUserId) {
-        console.error('[getUserDirectReports] Could not extract user ID from provided token when userIdOrUpn is not specified.');
+        logger.error('[getUserDirectReports] Could not extract user ID from provided token when userIdOrUpn is not specified.');
         return [];
       }
     } else {
@@ -255,7 +256,7 @@ export async function getUserDirectReports(token: string, userIdOrUpn?: string):
 
     if (!response.ok) {
       const body = await response.text();
-      console.error('❌ Error fetching direct reports:', {
+      logger.error('❌ Error fetching direct reports:', {
         status: response.status,
         statusText: response.statusText,
         error: body,
@@ -266,7 +267,7 @@ export async function getUserDirectReports(token: string, userIdOrUpn?: string):
     const data = await response.json();
     return data.value || [];
   } catch (error) {
-    console.error('Error fetching direct reports:', error);
+    logger.error('Error fetching direct reports:', error);
     return [];
   }
 }
@@ -341,7 +342,7 @@ export function withAuth(handler: (req: AuthenticatedRequest, res: NextApiRespon
       );
 
       if (employeeCheck.length === 0) {
-        console.error('[AuthMiddleware] Employee validation FAILED. No match found for:', {
+        logger.error('[AuthMiddleware] Employee validation FAILED. No match found for:', {
           selectedEmployeeId,
           userId: userData.id,
           queryResult: employeeCheck
@@ -364,7 +365,7 @@ export function withAuth(handler: (req: AuthenticatedRequest, res: NextApiRespon
       // Call the handler
       await handler(req, res);
     } catch (error) {
-      console.error('Authentication error in withAuth:', error);
+      logger.error('Authentication error in withAuth:', error);
       
       if (error instanceof InteractionRequiredAuthError) {
         return res.status(401).json({ 

--- a/src/pages/api/auth/validate-token.ts
+++ b/src/pages/api/auth/validate-token.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { ConfidentialClientApplication } from '@azure/msal-node';
 
@@ -46,7 +47,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('Graph API error:', {
+      logger.error('Graph API error:', {
         status: response.status,
         statusText: response.statusText,
         error: errorText
@@ -57,7 +58,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const userData = await response.json();
     return res.status(200).json({ id: userData.id });
   } catch (error) {
-    console.error('Token validation error:', error);
+    logger.error('Token validation error:', error);
     return res.status(401).json({ 
       error: 'Token validation failed',
       details: error instanceof Error ? error.message : 'Unknown error'

--- a/src/pages/api/candidates.ts
+++ b/src/pages/api/candidates.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 
 const pool = new Pool({
@@ -6,7 +7,7 @@ const pool = new Pool({
 });
 
 pool.on('error', (err) => {
-  console.error('Unexpected error on idle client', err);
+  logger.error('Unexpected error on idle client', err);
   process.exit(-1);
 });
 
@@ -20,7 +21,7 @@ async function checkUserAuthorization(req): Promise<{ authorized: boolean; userI
   try {
     userGroups = JSON.parse(req.headers['x-user-groups'] || '[]');
   } catch (e) {
-    console.error("Error parsing user groups:", e);
+    logger.error("Error parsing user groups:", e);
   }
 
   if (!userId) {
@@ -62,7 +63,7 @@ export default async function handler(req, res) {
       return res.status(200).json(result.rows);
 
     } catch (error) {
-      console.error('Erro ao buscar candidatos:', error);
+      logger.error('Erro ao buscar candidatos:', error);
       return res.status(500).json({ message: 'Erro ao buscar candidatos', error: error.message });
     }
   } else if (req.method === 'POST') {
@@ -147,14 +148,14 @@ export default async function handler(req, res) {
           null          // No old_data for creation
         ]);
       } catch (logError) {
-        console.error('Failed to log candidate creation:', logError);
+        logger.error('Failed to log candidate creation:', logError);
         // Optionally, decide if a logging failure should affect the main response
       }
 
       return res.status(201).json(newCandidate);
 
     } catch (error) {
-      console.error('Erro ao criar candidato:', error);
+      logger.error('Erro ao criar candidato:', error);
       // Check for unique constraint violation for email (example)
       if (error.code === '23505' && error.constraint && error.constraint.includes('email')) {
         return res.status(409).json({ message: 'Erro ao criar candidato: O email fornecido já existe.', error: error.message });

--- a/src/pages/api/candidates/[id].ts
+++ b/src/pages/api/candidates/[id].ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 
 const pool = new Pool({
@@ -6,7 +7,7 @@ const pool = new Pool({
 });
 
 pool.on('error', (err) => {
-  console.error('Unexpected error on idle client', err);
+  logger.error('Unexpected error on idle client', err);
   process.exit(-1);
 });
 
@@ -19,7 +20,7 @@ async function checkUserAuthorization(req): Promise<{ authorized: boolean; userI
   try {
     userGroups = JSON.parse(req.headers['x-user-groups'] || '[]');
   } catch (e) {
-    console.error("Error parsing user groups:", e);
+    logger.error("Error parsing user groups:", e);
   }
 
   if (!userId) return { authorized: false };
@@ -106,7 +107,7 @@ export default async function handler(req, res) {
           oldData
         ]);
       } catch (logError) {
-        console.error('Failed to log candidate update:', logError);
+        logger.error('Failed to log candidate update:', logError);
         // Not rolling back for logging failure, but logging the error
       }
 
@@ -115,7 +116,7 @@ export default async function handler(req, res) {
 
     } catch (error) {
       await client.query('ROLLBACK');
-      console.error('Erro ao atualizar candidato:', error);
+      logger.error('Erro ao atualizar candidato:', error);
       if (error.code === '23505' && error.constraint && error.constraint.includes('email')) {
         return res.status(409).json({ message: 'Erro ao atualizar candidato: O email fornecido já existe para outro candidato.', error: error.message });
       }
@@ -136,7 +137,7 @@ export default async function handler(req, res) {
       return res.status(200).json({ message: 'Candidato removido com sucesso.', deletedCandidate: result.rows[0] });
 
     } catch (error) {
-      console.error('Erro ao remover candidato:', error);
+      logger.error('Erro ao remover candidato:', error);
       return res.status(500).json({ message: 'Erro ao remover candidato', error: error.message });
     }
   } else {

--- a/src/pages/api/create-postgres-tables.js
+++ b/src/pages/api/create-postgres-tables.js
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 require('dotenv').config({ path: '.env.local' });
 const { Client } = require('pg');
 
@@ -191,7 +192,7 @@ async function main() {
 
 
   } catch (err) {
-    console.error('Error creating tables:', err);
+    logger.error('Error creating tables:', err);
     process.exit(1);
   } finally {
     await pgClient.end();

--- a/src/pages/api/employee.ts
+++ b/src/pages/api/employee.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import sql from 'mssql';
 
 const sqlConfig = {
@@ -90,8 +91,8 @@ export default async function handler(req, res) {
 
     res.status(200).json(result.recordset);
   } catch (error) {
-    console.error('Database error:', error);
-    console.error('Error details:', {
+    logger.error('Database error:', error);
+    logger.error('Error details:', {
       code: error.code,
       message: error.message,
       stack: error.stack,

--- a/src/pages/api/evaluation-create-schema.ts
+++ b/src/pages/api/evaluation-create-schema.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 import fs from 'fs';
 import path from 'path';
@@ -30,7 +31,7 @@ export default async function handler(req, res) {
     });
   } catch (error) {
     await client.query('ROLLBACK');
-    console.error('Error creating evaluation schema:', error);
+    logger.error('Error creating evaluation schema:', error);
     res.status(500).json({ 
       success: false, 
       error: error.message,

--- a/src/pages/api/evaluation-create-table.ts
+++ b/src/pages/api/evaluation-create-table.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import fs from 'fs';
@@ -224,7 +225,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.status(200).json({ message: 'Tables created successfully' });
   } catch (error) {
     await client.query('ROLLBACK');
-    console.error('Error creating tables:', error);
+    logger.error('Error creating tables:', error);
     res.status(500).json({ 
       message: 'Error creating tables',
       error: error.message,

--- a/src/pages/api/evaluation-matrices/[matrixId].ts
+++ b/src/pages/api/evaluation-matrices/[matrixId].ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import { withAuth, AuthenticatedRequest, isAdmin, getUserDirectReports } from '../../../middleware/auth';
@@ -49,7 +50,7 @@ async function canUserManageMatrix(
         return { authorized: true, matrix, creatorUpn };
       }
     } catch (error) {
-      console.error('Error fetching direct reports for matrix authorization:', error);
+      logger.error('Error fetching direct reports for matrix authorization:', error);
       // Potentially fall through or return a specific error if Graph call fails
       return { authorized: false, statusCode: 500, message: 'Could not verify manager relationship due to Graph API error.' };
     }
@@ -145,7 +146,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
 
       const validationResult = await validateMatrixInput({ title, description, valid_from, valid_to, criteria, employee_ids });
       if (!validationResult.success) {
-        console.error("PUT /matrixId validation error:", validationResult.errors);
+        logger.error("PUT /matrixId validation error:", validationResult.errors);
         res.status(400).json({ message: 'Invalid input', errors: validationResult.errors });
         return;
       }
@@ -295,7 +296,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
     if (client) {
       await client.query('ROLLBACK');
     }
-    console.error(`Error in /api/evaluation-matrices/${matrixId} API:`, error);
+    logger.error(`Error in /api/evaluation-matrices/${matrixId} API:`, error);
     if (error.code === '23503') { // foreign key violation
         res.status(409).json({ message: 'Conflict: Operation violates data integrity. The matrix might be in use.', details: error.detail });
     } else {

--- a/src/pages/api/evaluation-matrices/[matrixId]/applicability.ts
+++ b/src/pages/api/evaluation-matrices/[matrixId]/applicability.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 
@@ -21,7 +22,7 @@ async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string
       const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
     } catch (err) {
-      console.error('Failed to decode authorization token', err);
+      logger.error('Failed to decode authorization token', err);
     }
   }
 
@@ -59,7 +60,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ message: 'Forbidden: Selected Employee ID required for this operation.' });
     }
   } catch (authError) {
-    console.error('Authentication error in matrix applicability API:', authError);
+    logger.error('Authentication error in matrix applicability API:', authError);
     return res.status(500).json({ message: 'Authentication failed.' });
   }
 
@@ -86,7 +87,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         return res.status(200).json(result.rows);
       } catch (dbError) {
-        console.error(`Error fetching applicability for matrix ${matrixId}:`, dbError);
+        logger.error(`Error fetching applicability for matrix ${matrixId}:`, dbError);
         return res.status(500).json({ message: `Error fetching applicability`, error: dbError.message });
       }
     } else if (method === 'POST') {
@@ -148,7 +149,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(200).json(updatedApplicability.rows);
       } catch (dbError) {
         await client.query('ROLLBACK');
-        console.error(`Error adding applicability for matrix ${matrixId}:`, dbError);
+        logger.error(`Error adding applicability for matrix ${matrixId}:`, dbError);
         return res.status(500).json({ message: `Error adding applicability`, error: dbError.message });
       }
     } else if (method === 'DELETE') {
@@ -182,7 +183,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         });
       } catch (dbError) {
         await client.query('ROLLBACK');
-        console.error(`Error removing applicability for matrix ${matrixId}:`, dbError);
+        logger.error(`Error removing applicability for matrix ${matrixId}:`, dbError);
         return res.status(500).json({ message: `Error removing applicability`, error: dbError.message });
       }
     } else {
@@ -190,7 +191,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(405).end(`Method ${method} Not Allowed for this route.`);
     }
   } catch (error) {
-    console.error('General API handler error in matrix applicability API:', error);
+    logger.error('General API handler error in matrix applicability API:', error);
     return res.status(500).json({ message: 'An unexpected error occurred in matrix applicability API.', error: error.message });
   } finally {
     if (client) client.release();

--- a/src/pages/api/evaluation-matrices/[matrixId]/criteria.ts
+++ b/src/pages/api/evaluation-matrices/[matrixId]/criteria.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 
@@ -20,7 +21,7 @@ async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string
       const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
     } catch (err) {
-      console.error('Failed to decode authorization token', err);
+      logger.error('Failed to decode authorization token', err);
     }
   }
 
@@ -58,7 +59,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ message: 'Forbidden: Selected Employee ID required for this operation.' });
     }
   } catch (authError) {
-    console.error('Authentication error in matrix criteria API:', authError);
+    logger.error('Authentication error in matrix criteria API:', authError);
     return res.status(500).json({ message: 'Authentication failed.' });
   }
 
@@ -83,7 +84,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         return res.status(200).json(result.rows);
       } catch (dbError) {
-        console.error(`Error fetching criteria for matrix ${matrixId}:`, dbError);
+        logger.error(`Error fetching criteria for matrix ${matrixId}:`, dbError);
         return res.status(500).json({ message: `Error fetching criteria`, error: dbError.message });
       }
     } else if (method === 'POST') {
@@ -132,7 +133,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(201).json(result.rows[0]);
       } catch (dbError) {
         await client.query('ROLLBACK');
-        console.error(`Error adding criterion for matrix ${matrixId}:`, dbError);
+        logger.error(`Error adding criterion for matrix ${matrixId}:`, dbError);
         return res.status(500).json({ message: `Error adding criterion`, error: dbError.message });
       }
     } else if (method === 'PUT') {
@@ -207,7 +208,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(200).json(updatedCriteria.rows);
       } catch (dbError) {
         await client.query('ROLLBACK');
-        console.error(`Error updating criteria for matrix ${matrixId}:`, dbError);
+        logger.error(`Error updating criteria for matrix ${matrixId}:`, dbError);
         return res.status(500).json({ message: `Error updating criteria`, error: dbError.message });
       }
     } else if (method === 'DELETE') {
@@ -252,7 +253,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         });
       } catch (dbError) {
         await client.query('ROLLBACK');
-        console.error(`Error deleting criteria for matrix ${matrixId}:`, dbError);
+        logger.error(`Error deleting criteria for matrix ${matrixId}:`, dbError);
         return res.status(500).json({ message: `Error deleting criteria`, error: dbError.message });
       }
     } else {
@@ -260,7 +261,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(405).end(`Method ${method} Not Allowed for this route.`);
     }
   } catch (error) {
-    console.error('General API handler error in matrix criteria API:', error);
+    logger.error('General API handler error in matrix criteria API:', error);
     return res.status(500).json({ message: 'An unexpected error occurred in matrix criteria API.', error: error.message });
   } finally {
     if (client) client.release();

--- a/src/pages/api/evaluation-matrices/index.ts
+++ b/src/pages/api/evaluation-matrices/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getAllActiveEmployees, getEmployeeDetailsByUserId, getEmployeeDetailsByNumber } from '../../../lib/employeeDbService';
@@ -46,7 +47,7 @@ async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string
       const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
     } catch (err) {
-      console.error('Failed to decode authorization token', err);
+      logger.error('Failed to decode authorization token', err);
     }
   }
 
@@ -145,7 +146,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
           finalParams = [false, allowedCreatorUpns]; // $1=isAdmin (false), $2=array of allowed UPNs
 
         } catch (graphError) {
-          console.error('Failed to fetch direct reports from Graph API:', graphError);
+          logger.error('Failed to fetch direct reports from Graph API:', graphError);
           return res.status(500).json({ message: 'Failed to retrieve subordinate data for matrix filtering.', details: graphError.message });
         }
       }
@@ -183,7 +184,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
 
       const validationResult = await validateMatrixInput(req.body);
       if (!validationResult.success) {
-        console.error('[API POST Matrix] Input validation failed:', validationResult.errors);
+        logger.error('[API POST Matrix] Input validation failed:', validationResult.errors);
         return res.status(400).json({ message: 'Invalid input', errors: validationResult.errors });
       }
 
@@ -214,7 +215,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
           authorizedSubordinateEmployeeNumbers = subordinatesQuery.rows.map(r => r.employee_number.toString());
         }
       } catch (graphError) {
-        console.error('[POST Matrix Auth] Failed to fetch direct reports from Graph API:', graphError);
+        logger.error('[POST Matrix Auth] Failed to fetch direct reports from Graph API:', graphError);
         return res.status(500).json({ message: 'Failed to retrieve subordinate data for authorization.', details: graphError.message });
       }
 
@@ -313,7 +314,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
     if (client) {
       await client.query('ROLLBACK');
     }
-    console.error('Error in matrices API:', error);
+    logger.error('Error in matrices API:', error);
     // Check for specific error types if needed, e.g., error.code for pg errors
     if (error.code === '23505') { // Unique violation
         res.status(409).json({ message: 'Conflict: A similar record already exists.', details: error.detail });

--- a/src/pages/api/evaluation-matrix/applicability/[matrixId].ts
+++ b/src/pages/api/evaluation-matrix/applicability/[matrixId].ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 
@@ -31,7 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     return res.status(200).json(result.rows);
   } catch (error) {
-    console.error('Error fetching matrix applicability:', error);
+    logger.error('Error fetching matrix applicability:', error);
     return res.status(500).json({ message: 'Internal server error' });
   } finally {
     client.release();

--- a/src/pages/api/evaluation/create-table.ts
+++ b/src/pages/api/evaluation/create-table.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 
 const pgPool = new Pool({
@@ -199,8 +200,8 @@ export default async function handler(req, res) {
     res.status(200).json({ message: 'Tables created successfully' });
   } catch (error) {
     await client.query('ROLLBACK');
-    console.error('Error creating tables:', error);
-    console.error('Error details:', {
+    logger.error('Error creating tables:', error);
+    logger.error('Error details:', {
       message: error.message,
       code: error.code,
       detail: error.detail,

--- a/src/pages/api/evaluation/criteria/[criterionId].ts
+++ b/src/pages/api/evaluation/criteria/[criterionId].ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import { withAuth, AuthenticatedRequest, isAdmin, isManager } from '../../../../middleware/auth';
@@ -23,7 +24,7 @@ async function getAuthenticatedSystemUserId(req: AuthenticatedRequest): Promise<
       const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
     } catch (err) {
-      console.error('Failed to decode authorization token', err);
+      logger.error('Failed to decode authorization token', err);
     }
   }
 
@@ -286,7 +287,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
     if (client) {
       await client.query('ROLLBACK');
     }
-    console.error('Error in criterion API:', error);
+    logger.error('Error in criterion API:', error);
     res.status(500).json({ message: 'Internal server error', error: error.message });
     return;
   } finally {

--- a/src/pages/api/evaluation/matrices/[matrixId].ts
+++ b/src/pages/api/evaluation/matrices/[matrixId].ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import { canAccessMatrix, canManageMatrix } from '../../../../lib/evaluation/auth';
@@ -24,7 +25,7 @@ async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string
       const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
     } catch (err) {
-      console.error('Failed to decode authorization token', err);
+      logger.error('Failed to decode authorization token', err);
     }
   }
 
@@ -278,7 +279,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
     if (client) {
       await client.query('ROLLBACK');
     }
-    console.error('Error in matrix API:', error);
+    logger.error('Error in matrix API:', error);
     res.status(500).json({ message: 'Internal server error', error: error.message });
     return;
   } finally {

--- a/src/pages/api/evaluation/matrices/[matrixId]/applicability.ts
+++ b/src/pages/api/evaluation/matrices/[matrixId]/applicability.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import { canAccessMatrix, canManageMatrix } from '../../../../../lib/evaluation/auth';
@@ -23,7 +24,7 @@ async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string
       const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
     } catch (err) {
-      console.error('Failed to decode authorization token', err);
+      logger.error('Failed to decode authorization token', err);
     }
   }
 
@@ -69,7 +70,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ message: 'Forbidden: Selected Employee ID required for matrix operations.' });
     }
   } catch (authError) {
-    console.error('Authentication error in matrices API:', authError);
+    logger.error('Authentication error in matrices API:', authError);
     return res.status(500).json({ message: 'Authentication failed.' });
   }
 
@@ -101,7 +102,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         return res.status(200).json(result.rows);
       } catch (error) {
-        console.error('Error fetching matrix applicability:', error);
+        logger.error('Error fetching matrix applicability:', error);
         return res.status(500).json({ message: 'Error fetching matrix applicability', error: error.message });
       }
     } else if (method === 'POST') {
@@ -166,7 +167,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(200).json(updatedResult.rows);
       } catch (error) {
         await client.query('ROLLBACK');
-        console.error('Error updating matrix applicability:', error);
+        logger.error('Error updating matrix applicability:', error);
         return res.status(500).json({ message: 'Error updating matrix applicability', error: error.message });
       }
     } else if (method === 'DELETE') {
@@ -191,7 +192,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(200).json({ message: 'Matrix applicability removed successfully' });
       } catch (error) {
         await client.query('ROLLBACK');
-        console.error('Error removing matrix applicability:', error);
+        logger.error('Error removing matrix applicability:', error);
         return res.status(500).json({ message: 'Error removing matrix applicability', error: error.message });
       }
     } else {
@@ -199,7 +200,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(405).end(`Method ${method} Not Allowed`);
     }
   } catch (error) {
-    console.error('General API handler error in matrices API:', error);
+    logger.error('General API handler error in matrices API:', error);
     return res.status(500).json({ message: 'An unexpected error occurred', error: error.message });
   } finally {
     client.release();

--- a/src/pages/api/evaluation/matrices/[matrixId]/criteria.ts
+++ b/src/pages/api/evaluation/matrices/[matrixId]/criteria.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 
@@ -22,7 +23,7 @@ async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string
       const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
     } catch (err) {
-      console.error('Failed to decode authorization token', err);
+      logger.error('Failed to decode authorization token', err);
     }
   }
 
@@ -54,7 +55,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ message: 'Unauthorized: System User ID not available.' });
     }
   } catch (authError) {
-    console.error('MATRIX_CRITERIA_API: Authentication error:', authError);
+    logger.error('MATRIX_CRITERIA_API: Authentication error:', authError);
     return res.status(500).json({ message: 'Authentication failed.' });
   }
 
@@ -103,7 +104,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       } catch (dbError) {
         await client.query('ROLLBACK');
-        console.error(`MATRIX_CRITERIA_API: Error creating criterion for matrix ${matrixId}:`, dbError);
+        logger.error(`MATRIX_CRITERIA_API: Error creating criterion for matrix ${matrixId}:`, dbError);
         if (dbError.code === '23505') { 
             return res.status(409).json({ message: `A criterion with the name '${req.body.name}' already exists for this matrix.`, code: dbError.code });
         } else if (dbError.message && dbError.message.includes('Criteria weights for matrix_id')) { 
@@ -118,7 +119,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const criteriaResult = await client.query('SELECT * FROM evaluation_criteria WHERE matrix_id = $1 ORDER BY name', [matrixId]);
         return res.status(200).json(criteriaResult.rows);
       } catch (dbError) {
-        console.error(`MATRIX_CRITERIA_API: Error fetching criteria for matrix ${matrixId}:`, dbError);
+        logger.error(`MATRIX_CRITERIA_API: Error fetching criteria for matrix ${matrixId}:`, dbError);
         return res.status(500).json({ message: `Error fetching criteria for matrix ${matrixId}`, error: dbError.message });
       }
     }else {
@@ -126,7 +127,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(405).end(`Method ${method} Not Allowed for this route.`);
     }
   } catch (error) {
-    console.error('MATRIX_CRITERIA_API: General API handler error:', error);
+    logger.error('MATRIX_CRITERIA_API: General API handler error:', error);
     if (!res.headersSent) {
       return res.status(500).json({ message: 'An unexpected error occurred in criteria API.', error: error.message });
     }

--- a/src/pages/api/evaluation/matrices/index.ts
+++ b/src/pages/api/evaluation/matrices/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import { canManageMatrix } from '../../../../lib/evaluation/auth';
@@ -23,7 +24,7 @@ async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string
       const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
     } catch (err) {
-      console.error('Failed to decode authorization token', err);
+      logger.error('Failed to decode authorization token', err);
     }
   }
 
@@ -58,7 +59,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
   } catch (authError) {
-    console.error('Authentication error in matrices API:', authError);
+    logger.error('Authentication error in matrices API:', authError);
     return res.status(500).json({ message: 'Authentication failed.' });
   }
 
@@ -103,7 +104,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(200).json(result.rows);
 
       } catch (dbError) {
-        console.error('Error fetching matrices:', dbError);
+        logger.error('Error fetching matrices:', dbError);
         return res.status(500).json({ message: 'Error fetching matrices', error: dbError.message });
       }
     } else if (method === 'POST') {
@@ -154,7 +155,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       } catch (dbError) {
         await client.query('ROLLBACK');
-        console.error('Error creating matrix:', dbError);
+        logger.error('Error creating matrix:', dbError);
         if (dbError.code === '23505') { // Unique violation
           return res.status(409).json({ message: 'A matrix with this title already exists.', code: dbError.code });
         }
@@ -165,7 +166,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(405).end(`Method ${method} Not Allowed for this route.`);
     }
   } catch (error) {
-    console.error('General API handler error in matrices API:', error);
+    logger.error('General API handler error in matrices API:', error);
     return res.status(500).json({ message: 'An unexpected error occurred in matrices API.', error: error.message });
   } finally {
     if (client) client.release();

--- a/src/pages/api/evaluation/matrix/[id]/copy.ts
+++ b/src/pages/api/evaluation/matrix/[id]/copy.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import { getSession } from 'next-auth/react';
@@ -128,7 +129,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   } catch (error) {
     await client.query('ROLLBACK');
-    console.error('Error copying matrix:', error);
+    logger.error('Error copying matrix:', error);
     return res.status(500).json({ message: 'Internal server error' });
   } finally {
     client.release();

--- a/src/pages/api/evaluation/matrix/apply.ts
+++ b/src/pages/api/evaluation/matrix/apply.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import { getSession } from 'next-auth/react';
@@ -96,7 +97,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
   } catch (error) {
     await client.query('ROLLBACK');
-    console.error('Error applying matrix:', error);
+    logger.error('Error applying matrix:', error);
     res.status(500).json({ 
       message: 'Error applying matrix',
       error: error.message

--- a/src/pages/api/evaluation/notifications/check.ts
+++ b/src/pages/api/evaluation/notifications/check.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest, isAdmin } from '../../../middleware/auth';
 import { runNotificationChecks } from '../../../lib/evaluation/notificationService';
@@ -22,7 +23,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
     await runNotificationChecks();
     res.status(200).json({ message: 'Notification checks completed successfully' });
   } catch (error) {
-    console.error('Error running notification checks:', error);
+    logger.error('Error running notification checks:', error);
     res.status(500).json({ message: 'Error running notification checks', error: error.message });
   }
 }

--- a/src/pages/api/evaluation/notifications/index.ts
+++ b/src/pages/api/evaluation/notifications/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../middleware/auth';
 import { isAdmin } from '../../../../lib/auth';
@@ -60,7 +61,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise
       return;
     }
   } catch (error) {
-    console.error('Error in notifications API:', error);
+    logger.error('Error in notifications API:', error);
     res.status(500).json({ message: 'Internal server error', error: error.message });
     return;
   } finally {

--- a/src/pages/api/evaluation/self-evaluations.ts
+++ b/src/pages/api/evaluation/self-evaluations.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import { withAuth, AuthenticatedRequest, getUserManager } from '../../../middleware/auth';
@@ -26,7 +27,7 @@ async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string
       const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
       return decoded.oid || decoded.sub || decoded.userPrincipalName || decoded.upn || null;
     } catch (err) {
-      console.error('Failed to decode authorization token', err);
+      logger.error('Failed to decode authorization token', err);
     }
   }
 

--- a/src/pages/api/evaluation/user-role-info.ts
+++ b/src/pages/api/evaluation/user-role-info.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as jose from 'jose';
 import sql from 'mssql';
@@ -71,7 +72,7 @@ const AUDIENCE = process.env.AZURE_AD_API_AUDIENCE; // This should be the client
 
 async function validateUserToken(token: string): Promise<jose.JWTPayload | null> {
   if (!AZURE_AD_TENANT_ID || !AUDIENCE) {
-    console.error('Backend: Missing Azure AD config for user token validation (TENANT_ID, API_AUDIENCE).');
+    logger.error('Backend: Missing Azure AD config for user token validation (TENANT_ID, API_AUDIENCE).');
     return null;
   }
   try {
@@ -79,7 +80,7 @@ async function validateUserToken(token: string): Promise<jose.JWTPayload | null>
     const { payload } = await jose.jwtVerify(token, JWKS, { issuer: ISSUER, audience: AUDIENCE });
     return payload;
   } catch (error: any) {
-    console.error('User token validation error:', error.message);
+    logger.error('User token validation error:', error.message);
     return null;
   }
 }
@@ -90,7 +91,7 @@ async function getGraphToken(): Promise<string | null> {
     const authResult = await cca.acquireTokenByClientCredential({ scopes: GRAPH_SCOPES });
     return authResult?.accessToken || null;
   } catch (error) {
-    console.error('Failed to acquire Graph token by client credential:', error);
+    logger.error('Failed to acquire Graph token by client credential:', error);
     return null;
   }
 }
@@ -117,7 +118,7 @@ async function getEmployeeFromDbByUpn(userPrincipalName: string): Promise<any | 
       .query`SELECT [Number] AS EmployeeId, Name, Email, UserId FROM [RFWebApp].[dbo].[Employee] WHERE UserId = @userPrincipalName`;
     return result.recordset[0] || null;
   } catch (dbError) {
-    console.error(`DB error fetching employee by UPN ${userPrincipalName}:`, dbError);
+    logger.error(`DB error fetching employee by UPN ${userPrincipalName}:`, dbError);
     return null;
   }
 }
@@ -159,7 +160,7 @@ async function getEmployeesFromDbByUpns(userPrincipalNames: string[]): Promise<D
     const result = await request.query(query);
     return result.recordset as DbEmployeeDetails[];
   } catch (dbError) {
-    console.error(`DB error fetching employees by UPNs:`, dbError);
+    logger.error(`DB error fetching employees by UPNs:`, dbError);
     return []; 
   }
 }
@@ -246,7 +247,7 @@ export default async function handler(
     } catch (managerError: any) {
         if (managerError.message && managerError.message.includes('404')) {
         } else {
-            console.error('Error fetching manager from Graph:', managerError);
+            logger.error('Error fetching manager from Graph:', managerError);
         }
     }
 
@@ -265,7 +266,7 @@ export default async function handler(
     });
 
   } catch (err: any) {
-    console.error('API Error processing user role info with Graph:', err);
+    logger.error('API Error processing user role info with Graph:', err);
     await sql.close();
     return res.status(500).json({ 
       error: 'Internal Server Error', 

--- a/src/pages/api/recruitment-create-table.ts
+++ b/src/pages/api/recruitment-create-table.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 
 const pool = new Pool({
@@ -182,7 +183,7 @@ export default async function handler(req, res) {
     res.status(200).json({ success: true, message: 'All tables (recruitment, logs, admission, candidates) verified/updated successfully.' });
   } catch (error) {
     await client.query('ROLLBACK'); // Rollback transaction on error
-    console.error('Erro ao criar/atualizar tabelas:', error);
+    logger.error('Erro ao criar/atualizar tabelas:', error);
     res.status(500).json({ success: false, error: error.message });
   } finally {
     client.release(); // Release client

--- a/src/pages/api/recruitment-log.ts
+++ b/src/pages/api/recruitment-log.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 
 const pool = new Pool({
@@ -22,7 +23,7 @@ export default async function handler(req, res) {
     );
     res.status(200).json(result.rows);
   } catch (error) {
-    console.error('Erro ao buscar histórico:', error);
+    logger.error('Erro ao buscar histórico:', error);
     res.status(500).json({ message: 'Erro ao buscar histórico', error: error.message });
   }
 }

--- a/src/pages/api/recruitment.ts
+++ b/src/pages/api/recruitment.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg';
 
 const pool = new Pool({
@@ -7,7 +8,7 @@ const pool = new Pool({
 
 // Test connection on startup
 pool.on('error', (err) => {
-  console.error('Unexpected error on idle client', err);
+  logger.error('Unexpected error on idle client', err);
   process.exit(-1);
 });
 
@@ -46,8 +47,8 @@ export default async function handler(req, res) {
         }
         return res.status(200).json(pedido);
       } catch (error) {
-        console.error('Erro ao buscar pedido:', error);
-        console.error('Connection string:', process.env.DATABASE_URL ? 'Defined' : 'Not defined');
+        logger.error('Erro ao buscar pedido:', error);
+        logger.error('Connection string:', process.env.DATABASE_URL ? 'Defined' : 'Not defined');
         return res.status(500).json({ message: 'Erro ao buscar pedido', error: error.message });
       }
     }
@@ -61,9 +62,9 @@ export default async function handler(req, res) {
       );
       return res.status(200).json(result.rows);
     } catch (error) {
-      console.error('Erro ao buscar pedidos de recrutamento:', error);
-      console.error('Connection string:', process.env.DATABASE_URL ? 'Defined' : 'Not defined');
-      console.error('Error details:', {
+      logger.error('Erro ao buscar pedidos de recrutamento:', error);
+      logger.error('Connection string:', process.env.DATABASE_URL ? 'Defined' : 'Not defined');
+      logger.error('Error details:', {
         code: error.code,
         message: error.message,
         stack: error.stack
@@ -139,7 +140,7 @@ export default async function handler(req, res) {
       );
       res.status(200).json({ success: true, id: result.rows[0].id });
     } catch (error) {
-      console.error('Erro ao gravar recrutamento:', error);
+      logger.error('Erro ao gravar recrutamento:', error);
       res.status(500).json({ success: false, error: error.message });
     }
   } else if (req.method === 'PUT') {
@@ -196,7 +197,7 @@ export default async function handler(req, res) {
       );
       res.status(200).json({ success: true, data: result.rows[0] });
     } catch (error) {
-      console.error('Erro ao atualizar pedido:', error);
+      logger.error('Erro ao atualizar pedido:', error);
       res.status(500).json({ success: false, error: error.message });
     }
   } else {

--- a/src/pages/api/recruitment/[id]/[action].ts
+++ b/src/pages/api/recruitment/[id]/[action].ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { Pool } from 'pg'; // Assuming you have 'pg' installed
 // import { getToken } from 'next-auth/jwt'; // Keep if you plan to use it for more direct auth
 
@@ -30,7 +31,7 @@ async function checkUserAuthorization(req): Promise<{ authorized: boolean; userI
         return { authorized: true, userId, userName };
       }
     } catch (error) {
-      console.error("Error parsing user groups for authorization:", error);
+      logger.error("Error parsing user groups for authorization:", error);
       // Fall through to return not authorized
     }
   }
@@ -102,7 +103,7 @@ export default async function handler(req, res) {
       return res.status(200).json({ success: true, message: 'Pedido rejeitado com sucesso.' });
     }
   } catch (error) {
-    console.error(`Database error during ${action} action:`, error);
+    logger.error(`Database error during ${action} action:`, error);
     return res.status(500).json({ message: `Error processing request: ${error.message}` });
   } finally {
     if (client) {

--- a/src/pages/api/syncEmployees.js
+++ b/src/pages/api/syncEmployees.js
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 /*************************************************************
  * 💾 ENVIO DE FUNCIONÁRIOS                                 *
  * DA BASE DE DADOS SQL SERVER (interna da RF)              *
@@ -189,14 +190,14 @@ async function main() {
         ]);
         successCount++;
       } catch (err) {
-        console.error(`Error syncing employee ${emp.Number}:`, err);
+        logger.error(`Error syncing employee ${emp.Number}:`, err);
         errorCount++;
       }
     }
 
 
   } catch (err) {
-    console.error('Error during sync:', err);
+    logger.error('Error during sync:', err);
     process.exit(1);
   } finally {
     await sql.close();

--- a/src/pages/candidate-management/[requestId].tsx
+++ b/src/pages/candidate-management/[requestId].tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, Briefcase, Users, Building2, FileText, CalendarDays, Info, C
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { logger } from '@/lib/logger';
 import {
   Dialog,
   DialogContent,
@@ -224,7 +225,7 @@ export default function CandidateManagementPage() {
       const data = await res.json();
       setCandidatesByStage(prev => ({ ...prev, [stageId]: data }));
     } catch (err: any) {
-      console.error(`Erro ao buscar candidatos para ${stageId}:`, err);
+      logger.error(`Erro ao buscar candidatos para ${stageId}:`, err);
       setCandidatesByStage(prev => ({ ...prev, [stageId]: [] })); // Set to empty array on error
     } finally {
       setLoadingCandidates(prev => ({ ...prev, [stageId]: false }));
@@ -257,7 +258,7 @@ export default function CandidateManagementPage() {
       return;
     }
     
-    console.log(`Candidate ${candidateId} dragged from stage ${sourceStageId} (index ${source.index}) to stage ${destStageId} (index ${destination.index})`);
+    logger.log(`Candidate ${candidateId} dragged from stage ${sourceStageId} (index ${source.index}) to stage ${destStageId} (index ${destination.index})`);
 
     // Optimistically update UI
     setCandidatesByStage(prev => {
@@ -310,10 +311,10 @@ export default function CandidateManagementPage() {
         const errorResult = await res.json().catch(() => ({ message: "Failed to update candidate stage on server." }));
         throw new Error(errorResult.message);
       }
-      console.log(`Candidate ${candidateId} stage updated to ${newStage} on server.`);
+      logger.log(`Candidate ${candidateId} stage updated to ${newStage} on server.`);
       // Optionally, show a success toast or notification
     } catch (error: any) {
-      console.error("Error updating candidate stage on server:", error);
+      logger.error("Error updating candidate stage on server:", error);
       // Revert optimistic update if API call fails?
       // This can be complex, for now, we log error and might show a toast.
       // Consider re-fetching candidates for source/destination stages to ensure consistency.

--- a/src/pages/evaluation/evaluate.tsx
+++ b/src/pages/evaluation/evaluate.tsx
@@ -5,6 +5,7 @@ import { useMsal } from '@azure/msal-react';
 import { InteractionRequiredAuthError, InteractionStatus, PublicClientApplication } from '@azure/msal-browser';
 import { fetchWithAuth, ApiClientOptions } from '@/lib/apiClient'; // Import fetchWithAuth
 import { useSelectedEmployee } from '@/contexts/SelectedEmployeeContext'; // Import the context hook
+import { logger } from '@/lib/logger';
 
 // Define your API scopes here - this should match the audience/scope configured for your backend API
 // e.g., ["api://your-backend-client-id/.default"] or specific permission scopes
@@ -67,7 +68,7 @@ const EvaluateSubordinatePage = () => {
 
       try {
         // No need to acquire token manually, fetchWithAuth handles it.
-        console.log("Fetching user role info...");
+        logger.log("Fetching user role info...");
         const data = await fetchWithAuth<UserRoleInfo>(
           '/api/evaluation/user-role-info',
           { method: 'GET' },
@@ -81,19 +82,19 @@ const EvaluateSubordinatePage = () => {
         setEmployeeProfileName(data.name); 
         setIsManagerRole(data.isManager);
 
-        console.log("Fetched User Info Subordinates:", data.subordinates);
-        console.log("Context updated: selectedEmployeeId:", data.employeeId, "systemUserId:", data.userId);
+        logger.log("Fetched User Info Subordinates:", data.subordinates);
+        logger.log("Context updated: selectedEmployeeId:", data.employeeId, "systemUserId:", data.userId);
 
       } catch (err: any) {
         if (err instanceof InteractionRequiredAuthError) {
           console.warn('Silent token acquisition failed via fetchWithAuth. Interaction required.');
-          console.error("InteractionRequiredAuthError details:", err); 
+          logger.error("InteractionRequiredAuthError details:", err);
           setError(`Falha na aquisição de token: ${err.message || err.errorMessage}. Interação pode ser necessária.`);
           // Potentially trigger interactive token acquisition here if not handled globally by msal-react or _app.tsx
-          // instance.acquireTokenRedirect({ scopes: apiScopes, account: accounts[0] }).catch(console.error);
+          // instance.acquireTokenRedirect({ scopes: apiScopes, account: accounts[0] }).catch(logger.error);
         } else {
           setError(err.message || 'Falha ao carregar informação do utilizador.');
-          console.error("Other error during user-role-info fetch:", err); 
+          logger.error("Other error during user-role-info fetch:", err);
         }
       } finally {
         setIsLoading(false);

--- a/src/pages/evaluation/evaluate/[subordinateId].tsx
+++ b/src/pages/evaluation/evaluate/[subordinateId].tsx
@@ -5,6 +5,7 @@ import { useMsal } from '@azure/msal-react';
 import { InteractionStatus, InteractionRequiredAuthError, PublicClientApplication } from '@azure/msal-browser';
 import { fetchWithAuth, ApiClientOptions } from '@/lib/apiClient';
 import { useSelectedEmployee } from '@/contexts/SelectedEmployeeContext';
+import { logger } from '@/lib/logger';
 
 // Placeholder interfaces - these would be defined based on your actual API response
 interface EvaluationCriterion {
@@ -70,7 +71,7 @@ const EvaluationFormPage = () => {
       };
 
       try {
-        console.log(`Fetching evaluation data for subordinate: ${subordinateId}, by manager: ${managerEmployeeId}`);
+        logger.log(`Fetching evaluation data for subordinate: ${subordinateId}, by manager: ${managerEmployeeId}`);
         // TODO: Replace with actual API endpoint and data structure
         // This endpoint would need to:
         // 1. Find or initiate an employee_evaluation for the subordinateId, managerEmployeeId, and current period/matrix.
@@ -84,7 +85,7 @@ const EvaluationFormPage = () => {
         );
         setEvaluationData(fetchedData);
       } catch (err: any) {
-        console.error("Error fetching evaluation details:", err);
+        logger.error("Error fetching evaluation details:", err);
         if (err instanceof InteractionRequiredAuthError) {
           setError("Sessão expirada ou requer interação. Por favor, tente autenticar novamente.");
           // Potentially trigger interactive login

--- a/src/pages/evaluation/matrices.tsx
+++ b/src/pages/evaluation/matrices.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-toastify';
 import { PlusIcon, PencilSquareIcon, DocumentDuplicateIcon, TrashIcon, CalendarDaysIcon, ClipboardDocumentListIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { useSelectedEmployee } from '../../contexts/SelectedEmployeeContext'; // Added
 import { fetchWithAuth } from '../../lib/apiClient'; // Added
+import { logger } from '@/lib/logger';
 import { InteractionStatus, type AccountInfo } from '@azure/msal-browser'; // Added for enum usage
 import { Dialog, Transition } from '@headlessui/react';
 import { useRouter } from 'next/router';
@@ -62,21 +63,21 @@ const formatDate = (dateString: string) => {
     if (!hasTimeOrUTC && /\d{4}-\d{2}-\d{2}/.test(dateString.substring(0,10))) {
       // If it looks like YYYY-MM-DD without time, append T00:00:00Z for UTC parsing
       dateToParse = dateString.substring(0,10) + 'T00:00:00Z';
-      console.log(`formatDate: Appended T00:00:00Z to ${dateString.substring(0,10)}, parsing: ${dateToParse}`);
+      logger.log(`formatDate: Appended T00:00:00Z to ${dateString.substring(0,10)}, parsing: ${dateToParse}`);
     } else {
       // If it already has T or Z, or is not in YYYY-MM-DD format, try parsing as is
-      console.log(`formatDate: Parsing as is: ${dateToParse}`);
+      logger.log(`formatDate: Parsing as is: ${dateToParse}`);
     }
 
     const date = new Date(dateToParse);
     
     if (isNaN(date.getTime())) {
-      console.error("formatDate produced Invalid Date for input:", dateString, "Parsed as:", dateToParse);
+      logger.error("formatDate produced Invalid Date for input:", dateString, "Parsed as:", dateToParse);
       return 'Data Inválida (Parse)'; // More specific error
     }
     return date.toLocaleDateString('pt-BR', { timeZone: 'UTC' });
   } catch (e) {
-    console.error("Error formatting date (exception):", dateString, e);
+    logger.error("Error formatting date (exception):", dateString, e);
     return 'Data Inválida (Catch)';
   }
 };
@@ -113,7 +114,7 @@ export default function EvaluationMatricesPage() {
   // Add immediate redirect if no selectedEmployeeId
   useEffect(() => {
     if (!selectedEmployeeId && !isLoading) {
-      console.log('No selected employee ID, redirecting to landing page');
+      logger.log('No selected employee ID, redirecting to landing page');
       router.replace('/landing');
     }
   }, [selectedEmployeeId, isLoading, router]);
@@ -121,7 +122,7 @@ export default function EvaluationMatricesPage() {
   // Add authentication check effect
   useEffect(() => {
     if (!msalInstance || !activeAccount || interactionStatus !== InteractionStatus.None) {
-      console.log('Authentication not ready:', {
+      logger.log('Authentication not ready:', {
         hasMsalInstance: !!msalInstance,
         hasActiveAccount: !!activeAccount,
         interactionStatus
@@ -130,7 +131,7 @@ export default function EvaluationMatricesPage() {
     }
 
     if (!selectedEmployeeId) {
-      console.log('No selected employee ID, redirecting to landing page');
+      logger.log('No selected employee ID, redirecting to landing page');
       router.replace('/landing');
       return;
     }
@@ -145,7 +146,7 @@ export default function EvaluationMatricesPage() {
       return;
     }
 
-    console.log('[MatricesPage] fetchMatrices called with selectedEmployeeId:', selectedEmployeeId);
+    logger.log('[MatricesPage] fetchMatrices called with selectedEmployeeId:', selectedEmployeeId);
     setIsLoading(true);
     setError(null);
 
@@ -166,7 +167,7 @@ export default function EvaluationMatricesPage() {
     } catch (err: any) {
       setError(err.message);
       toast.error(err.message);
-      console.error('[MatricesPage] Error in fetchMatrices:', err);
+      logger.error('[MatricesPage] Error in fetchMatrices:', err);
     } finally {
       setIsLoading(false);
     }
@@ -182,7 +183,7 @@ export default function EvaluationMatricesPage() {
       setSubordinates([]);
 
       if (msalInstance && currentActiveAccount && inProgress === InteractionStatus.None && selectedEmployeeId) {
-        console.log('[MatricesPage] Attempting to fetch subordinates and manager status. Manager ID:', selectedEmployeeId);
+        logger.log('[MatricesPage] Attempting to fetch subordinates and manager status. Manager ID:', selectedEmployeeId);
         try {
           const apiClientOpts = {
             msalInstance,
@@ -198,14 +199,14 @@ export default function EvaluationMatricesPage() {
           if (roleInfo) {
             setSubordinates(roleInfo.subordinates || []);
             setIsManager(roleInfo.isManager || false); // Store isManager
-            console.log('[MatricesPage] Fetched user role info:', {isManager: roleInfo.isManager, numSubordinates: roleInfo.subordinates?.length });
+            logger.log('[MatricesPage] Fetched user role info:', {isManager: roleInfo.isManager, numSubordinates: roleInfo.subordinates?.length });
           } else {
             setSubordinates([]);
             setIsManager(false);
-            console.log('[MatricesPage] No roleInfo received.');
+            logger.log('[MatricesPage] No roleInfo received.');
           }
         } catch (err: any) {
-          console.error('Failed to fetch subordinates/manager status:', err);
+          logger.error('Failed to fetch subordinates/manager status:', err);
           toast.error('Falha ao buscar lista de subordinados e status de gestor.');
           setSubordinates([]);
           setIsManager(false);
@@ -217,7 +218,7 @@ export default function EvaluationMatricesPage() {
   }, [msalInstance, accounts, inProgress, selectedEmployeeId]);
 
   useEffect(() => {
-    console.log('[MatricesPage] useEffect for fetching matrices triggered. Values:', {
+    logger.log('[MatricesPage] useEffect for fetching matrices triggered. Values:', {
         hasMsalInstance: !!msalInstance,
         accountsLength: accounts?.length,
         inProgressStatus: inProgress,
@@ -226,7 +227,7 @@ export default function EvaluationMatricesPage() {
 
     // 1. Wait for MSAL instance and for inProgress to be defined and not in startup/redirect phase.
     if (!msalInstance || inProgress === undefined || inProgress === InteractionStatus.Startup || inProgress === InteractionStatus.HandleRedirect) {
-        console.log('[MatricesPage] Waiting for MSAL initialization or redirect/startup to complete. isLoading remains true.');
+        logger.log('[MatricesPage] Waiting for MSAL initialization or redirect/startup to complete. isLoading remains true.');
         // setIsLoading(true); // Implicitly, isLoading is true initially or from previous state
         return; // Exit and wait for these dependencies to change and re-trigger useEffect
     }
@@ -237,10 +238,10 @@ export default function EvaluationMatricesPage() {
     // 2. Check if interaction is None (i.e., idle and ready)
     if (inProgress === InteractionStatus.None) {
         if (currentActiveAccount && selectedEmployeeId) {
-            console.log('[MatricesPage] Conditions fully met (MSAL Ready, InteractionStatus.None, Account, EmployeeID). Calling fetchMatrices().');
+            logger.log('[MatricesPage] Conditions fully met (MSAL Ready, InteractionStatus.None, Account, EmployeeID). Calling fetchMatrices().');
             fetchMatrices();
         } else {
-            console.log('[MatricesPage] MSAL Ready and InteractionStatus is None, but ActiveAccount or SelectedEmployeeId is missing. Not fetching.');
+            logger.log('[MatricesPage] MSAL Ready and InteractionStatus is None, but ActiveAccount or SelectedEmployeeId is missing. Not fetching.');
             setIsLoading(false); // Can stop loading as we won't fetch under these conditions
             if (!currentActiveAccount && msalInstance) { 
                 setError("Login necessário ou nenhuma conta ativa encontrada.");
@@ -251,7 +252,7 @@ export default function EvaluationMatricesPage() {
     } else {
         // Interaction is in progress (e.g., login, acquireToken) but not startup/redirect/undefined.
         // This means user interaction might be required or is ongoing.
-        console.log(`[MatricesPage] MSAL interaction is currently '${inProgress}'. Waiting for it to resolve to 'None'. isLoading remains true.`);
+        logger.log(`[MatricesPage] MSAL interaction is currently '${inProgress}'. Waiting for it to resolve to 'None'. isLoading remains true.`);
         // setIsLoading(true); // Keep loading, as we are actively waiting for an MSAL process
     }
      // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -278,7 +279,7 @@ export default function EvaluationMatricesPage() {
 
     if (!matrixId || matrixId === "undefined") {
       toast.error("ID da Matriz inválido para edição.");
-      console.error("[MatricesPage] handleEditMatrix: ID da matriz inválido:", matrixToEdit);
+      logger.error("[MatricesPage] handleEditMatrix: ID da matriz inválido:", matrixToEdit);
       setIsLoading(false);
       return;
     }
@@ -294,7 +295,7 @@ export default function EvaluationMatricesPage() {
         setEditingMatrix(matrixToEdit);
         setShowFormModal(true);
     } catch (err: any) {
-        console.error('[MatricesPage] Error fetching matrix for edit:', err);
+        logger.error('[MatricesPage] Error fetching matrix for edit:', err);
         toast.error(err.message);
         setError(err.message); // Set page error if needed, or rely on toast
     } finally {
@@ -335,7 +336,7 @@ export default function EvaluationMatricesPage() {
       return matrix?.applicable_employee_ids || [];
 
     } catch (error: any) {
-      console.error(`Error fetching applicability for matrix ${matrixId}:`, error);
+      logger.error(`Error fetching applicability for matrix ${matrixId}:`, error);
       toast.error(`Falha ao buscar aplicabilidade para a matriz ${matrixId}.`);
       return [];
     }
@@ -352,7 +353,7 @@ export default function EvaluationMatricesPage() {
 
     setIsLoading(true);
     if (!msalInstance || !activeAccount || interactionStatus !== InteractionStatus.None) {
-      console.error('[MatricesPage] handleSaveMatrix: Prerequisites for fetchWithAuth not met.');
+      logger.error('[MatricesPage] handleSaveMatrix: Prerequisites for fetchWithAuth not met.');
       toast.error("Não é possível salvar a matriz: contexto de autenticação inválido.");
       setIsLoading(false);
       return;
@@ -366,7 +367,7 @@ export default function EvaluationMatricesPage() {
       criteria: data.criteria.map(c => ({ ...c, weight: Number(c.weight) || 0 })),
     };
     
-    console.log('[MatricesPage] Saving matrix with data:', processedData);
+    logger.log('[MatricesPage] Saving matrix with data:', processedData);
 
     try {
       const apiClientOpts = {
@@ -376,7 +377,7 @@ export default function EvaluationMatricesPage() {
         selectedEmployeeId,
       };
       
-      console.log('[MatricesPage] handleSaveMatrix - Preparing to call fetchWithAuth. apiClientOpts:', {
+      logger.log('[MatricesPage] handleSaveMatrix - Preparing to call fetchWithAuth. apiClientOpts:', {
         msalInstanceExists: !!apiClientOpts.msalInstance,
         interactionStatus: apiClientOpts.interactionStatus,
         activeAccountExists: !!apiClientOpts.activeAccount,
@@ -398,7 +399,7 @@ export default function EvaluationMatricesPage() {
     } catch (err: any) {
       setError(err.message);
       toast.error(err.message);
-      console.error('[MatricesPage] Error saving matrix:', err);
+      logger.error('[MatricesPage] Error saving matrix:', err);
     } finally {
       setIsLoading(false);
     }
@@ -406,7 +407,7 @@ export default function EvaluationMatricesPage() {
 
   const handleDeleteMatrix = async (matrixIdToDelete?: string) => {
     if (!matrixIdToDelete || matrixIdToDelete === "undefined") {
-      console.error("[handleDeleteMatrix] ID da matriz é inválido ou não fornecido:", matrixIdToDelete);
+      logger.error("[handleDeleteMatrix] ID da matriz é inválido ou não fornecido:", matrixIdToDelete);
       toast.error("Erro ao inativar matriz: ID inválido.");
       setIsLoading(false); // Ensure loading state is reset
       return;
@@ -418,7 +419,7 @@ export default function EvaluationMatricesPage() {
 
     setIsLoading(true); // Set loading true only after confirmation and ID check
     if (!msalInstance || !activeAccount || interactionStatus !== InteractionStatus.None || !selectedEmployeeId) {
-      console.error('[MatricesPage] handleDeleteMatrix: Prerequisites for fetchWithAuth not met.');
+      logger.error('[MatricesPage] handleDeleteMatrix: Prerequisites for fetchWithAuth not met.');
       toast.error("Não é possível inativar a matriz: contexto de autenticação inválido.");
       setIsLoading(false);
       return;
@@ -441,7 +442,7 @@ export default function EvaluationMatricesPage() {
     } catch (err: any) {
       setError(err.message);
       toast.error(err.message);
-      console.error('[MatricesPage] Error deleting (inactivating) matrix:', err);
+      logger.error('[MatricesPage] Error deleting (inactivating) matrix:', err);
     } finally {
       setIsLoading(false);
     }
@@ -449,7 +450,7 @@ export default function EvaluationMatricesPage() {
 
   const handleCopyMatrix = async (matrixToCopy: EvaluationMatrix) => {
     if (!msalInstance || !activeAccount || interactionStatus !== InteractionStatus.None || !selectedEmployeeId) {
-      console.error('[MatricesPage] handleCopyMatrix: Prerequisites for fetchWithAuth not met.');
+      logger.error('[MatricesPage] handleCopyMatrix: Prerequisites for fetchWithAuth not met.');
       toast.error("Não é possível copiar a matriz: contexto de autenticação inválido.");
       return;
     }
@@ -457,7 +458,7 @@ export default function EvaluationMatricesPage() {
     // Ensure matrixToCopy has a valid ID before attempting to use its properties
     const idToCopyFrom = matrixToCopy.id || matrixToCopy.matrix_id;
     if (!idToCopyFrom) {
-        console.error("[MatricesPage] handleCopyMatrix: Matriz original não tem ID para copiar.", matrixToCopy);
+        logger.error("[MatricesPage] handleCopyMatrix: Matriz original não tem ID para copiar.", matrixToCopy);
         toast.error("Erro ao copiar: Matriz original sem ID.");
         return;
     }
@@ -479,7 +480,7 @@ export default function EvaluationMatricesPage() {
       ? newMatrixData.criteria.map(c => ({ ...c, id: undefined }))
       : [];
 
-    console.log('[MatricesPage] Attempting to save copied matrix:', newMatrixData);
+    logger.log('[MatricesPage] Attempting to save copied matrix:', newMatrixData);
     setShowFormModal(true);
     setEditingMatrix(newMatrixData); // Open form with copied data for potential edits before saving
     setSelectedApplicableEmployees(newMatrixData.applicable_employee_ids || []);
@@ -509,7 +510,7 @@ export default function EvaluationMatricesPage() {
     } catch (err: any) {
       setError(err.message);
       toast.error(`Erro ao copiar matriz: ${err.message}`);
-      console.error('[MatricesPage] Error copying matrix:', err);
+      logger.error('[MatricesPage] Error copying matrix:', err);
     } finally {
       setIsLoading(false);
     }
@@ -519,7 +520,7 @@ export default function EvaluationMatricesPage() {
   const handleShowApplications = async (matrix: EvaluationMatrix) => {
     const matrixIdToShow = matrix.id || matrix.matrix_id;
     if (!matrixIdToShow || matrixIdToShow === "undefined") {
-      console.error("[MatricesPage] handleShowApplications: ID da matriz inválido:", matrix);
+      logger.error("[MatricesPage] handleShowApplications: ID da matriz inválido:", matrix);
       toast.error("Erro ao ver aplicações: ID da matriz inválido.");
       return;
     }
@@ -730,7 +731,7 @@ export default function EvaluationMatricesPage() {
                           if (idToDel && idToDel !== "undefined") {
                             handleDeleteMatrix(idToDel);
                           } else {
-                            console.error("ID inválido no botão Apagar:", matrix);
+                            logger.error("ID inválido no botão Apagar:", matrix);
                             toast.error("Erro: ID da matriz inválido para apagar.");
                           }
                         }}

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -7,6 +7,7 @@ import { useFuncionario } from "../context/FuncionarioContext"; // Adjust path i
 import { useRouter } from "next/router";
 import Link from 'next/link'; // Added Link import
 import { useSelectedEmployee } from '@/contexts/SelectedEmployeeContext'; // Added
+import { logger } from '@/lib/logger';
 
 gsap.registerPlugin(Back);
 
@@ -113,7 +114,7 @@ const LandingPage: React.FC = () => {
   useEffect(() => {
     if (funcionarioSelecionado && typeof funcionarioSelecionado.employee_number === 'number') {
       const employeeIdStr = funcionarioSelecionado.employee_number.toString();
-      console.log(`[LandingPage] FuncionarioSelecionado valid, updating SelectedEmployeeContext with ID: ${employeeIdStr}`, funcionarioSelecionado);
+      logger.log(`[LandingPage] FuncionarioSelecionado valid, updating SelectedEmployeeContext with ID: ${employeeIdStr}`, funcionarioSelecionado);
       setSelectedEmployeeId(employeeIdStr);
       setEmployeeProfileName(funcionarioSelecionado.Name);
       
@@ -130,7 +131,7 @@ const LandingPage: React.FC = () => {
       setEmployeeProfileName(null);
       setIsManagerRole(false);
     } else {
-      console.log('[LandingPage] FuncionarioSelecionado deselected, clearing parts of SelectedEmployeeContext.');
+      logger.log('[LandingPage] FuncionarioSelecionado deselected, clearing parts of SelectedEmployeeContext.');
       setSelectedEmployeeId(null);
       setEmployeeProfileName(null);
       setIsManagerRole(false);

--- a/src/pages/recruitmentdashboard.tsx
+++ b/src/pages/recruitmentdashboard.tsx
@@ -9,6 +9,7 @@ import { LineChart, Line, XAxis, YAxis, CartesianGrid, PieChart, Pie, Cell, Tool
 import { BarChart, Bar } from 'recharts';
 import Link from 'next/link';
 import Head from 'next/head';
+import { logger } from '@/lib/logger';
 // Importe aqui os ícones e componentes necessários, ou substitua por placeholders se não existirem
 // import { Search, UserPlus, UserX, RefreshCw, BarChart2, Briefcase } from "lucide-react";
 // import { Input } from "@/components/ui/input";
@@ -163,7 +164,7 @@ export default function RecruitmentDashboard() {
   const userId = user?.username;
   const userGroups = Array.isArray(user?.idTokenClaims?.groups) ? user.idTokenClaims.groups : [];
   const isRH = userGroups.includes("a837ee80-f103-4d51-9869-e3b4da6bdeda");
-  console.log("Dashboard User Auth: userGroups", userGroups, "isRH", isRH);
+  logger.log("Dashboard User Auth: userGroups", userGroups, "isRH", isRH);
   const [hydrated, setHydrated] = useState(false);
 
   // State for approval/rejection workflow - MOVED EARLIER
@@ -215,7 +216,7 @@ export default function RecruitmentDashboard() {
         const monthYear = `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}`;
         acc[monthYear] = (acc[monthYear] || 0) + 1;
       } catch (e) {
-        console.error("Error processing date for pedido:", pedido.id, pedido.request_date, e);
+        logger.error("Error processing date for pedido:", pedido.id, pedido.request_date, e);
       }
     }
     return acc;
@@ -249,10 +250,10 @@ export default function RecruitmentDashboard() {
   }, []);
 
   // Log chart data for debugging
-  console.log("Estado Chart Data:", estadoChartData);
-  console.log("Departamento Chart Data:", departamentoChartData);
-  console.log("Monthly Chart Data:", monthlyChartData);
-  console.log("Contract Types Chart Data:", contractTypesChartData);
+  logger.log("Estado Chart Data:", estadoChartData);
+  logger.log("Departamento Chart Data:", departamentoChartData);
+  logger.log("Monthly Chart Data:", monthlyChartData);
+  logger.log("Contract Types Chart Data:", contractTypesChartData);
 
   const themeOptions = [
     { value: 'light', label: 'Claro', icon: '🌞' },
@@ -296,14 +297,14 @@ export default function RecruitmentDashboard() {
       setError(null);
       try {
         const azureUserId = accounts[0]?.username;
-        console.log("Fetching employees for Azure AD userId:", azureUserId);
+        logger.log("Fetching employees for Azure AD userId:", azureUserId);
         if (!azureUserId) {
           throw new Error("Azure AD User ID not available.");
         }
         const response = await fetch(`/api/employee?userId=${azureUserId}`);
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({ message: response.statusText }));
-          console.error("Error response from /api/employee:", response.status, errorData);
+          logger.error("Error response from /api/employee:", response.status, errorData);
           throw new Error(errorData.message || 'Erro ao buscar funcionários');
         }
         const data = await response.json();
@@ -410,7 +411,7 @@ export default function RecruitmentDashboard() {
     const pedido = pedidos.find(p => p.id === id);
     setPedidoSelecionado(pedido);
     setShowPedidoModal(true);
-    console.log("Opening Pedido Modal: pedidoSelecionado", pedido, "Estado do Pedido?", pedido?.estado);
+    logger.log("Opening Pedido Modal: pedidoSelecionado", pedido, "Estado do Pedido?", pedido?.estado);
     try {
       const res = await fetch(`/api/recruitment-log?recruitmentId=${id}`);
       const logs = await res.json();


### PR DESCRIPTION
## Summary
- create a simple logger utility
- remove `console.log` and `console.error` usages
- import and use the new logger across pages, components and API routes

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668d7ec79c8332aaf0afc37b1e5e31