### PR TITLE
Enhance MSAL configuration and add debugging tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The following variables are referenced in the code base:
 - `SQL_SERVER`
 - `SQL_USER`
 
-Refer to that file when creating your own `.env.local`.
+Refer to that file when creating your own `.env.local`. You can also run
+`npm run setup-env` to copy the example file automatically.
 
 ## Employee Selection Flow
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "setup-env": "node scripts/setup-env.js"
   },
   "dependencies": {
     "@ant-design/icons": "^6.0.0",

--- a/scripts/setup-env.js
+++ b/scripts/setup-env.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+const examplePath = path.join(__dirname, '..', '.env.local.example');
+const targetPath = path.join(__dirname, '..', '.env.local');
+
+if (fs.existsSync(targetPath)) {
+  console.log('.env.local already exists');
+  process.exit(0);
+}
+
+if (!fs.existsSync(examplePath)) {
+  console.error('Example env file not found:', examplePath);
+  process.exit(1);
+}
+
+fs.copyFileSync(examplePath, targetPath);
+console.log('Created .env.local from example');
+

--- a/src/components/MSALDebug.tsx
+++ b/src/components/MSALDebug.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { msalConfig } from '@/config/authConfig';
+
+const MSALDebug: React.FC = () => {
+  if (process.env.NODE_ENV !== 'development') return null;
+
+  const computedRedirect =
+    typeof window !== 'undefined'
+      ? (process.env.NEXT_PUBLIC_REDIRECT_URI || `${window.location.origin}/landing`)
+      : '';
+
+  const envInfo = {
+    NEXT_PUBLIC_AZURE_CLIENT_ID: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID,
+    NEXT_PUBLIC_AZURE_AUTHORITY: process.env.NEXT_PUBLIC_AZURE_AUTHORITY,
+    NEXT_PUBLIC_REDIRECT_URI: process.env.NEXT_PUBLIC_REDIRECT_URI,
+  };
+
+  return (
+    <div style={{ background: '#eee', padding: '1rem', marginTop: '1rem' }}>
+      <h3>MSAL Debug</h3>
+      <pre>{JSON.stringify({ envInfo, computedRedirect, msalConfig }, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default MSALDebug;

--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+import { useIsAuthenticated, useMsal } from '@azure/msal-react';
+import { logger } from '@/lib/logger';
+
+const RouteGuard: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
+  const isAuthenticated = useIsAuthenticated();
+  const { instance, inProgress } = useMsal();
+
+  useEffect(() => {
+    if (!isAuthenticated && inProgress === 'none') {
+      instance.loginRedirect().catch((err) => {
+        logger.error('[RouteGuard] loginRedirect failed:', err);
+      });
+    }
+  }, [isAuthenticated, inProgress, instance]);
+
+  if (!isAuthenticated) {
+    return <p className="p-4">A redirecionar para login...</p>;
+  }
+
+  return <>{children}</>;
+};
+
+export default RouteGuard;

--- a/src/config/authConfig.js
+++ b/src/config/authConfig.js
@@ -2,12 +2,14 @@ import { logger } from '@/lib/logger';
 import { LogLevel } from "@azure/msal-browser";
 
 
+const origin = typeof window !== 'undefined' ? window.location.origin : '';
+
 export const msalConfig = {
     auth: {
-        clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID,
-        authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY,
-        redirectUri: process.env.NEXT_PUBLIC_REDIRECT_URI || "http://localhost:3000/landing",
-        postLogoutRedirectUri: process.env.NEXT_PUBLIC_POST_LOGOUT_REDIRECT_URI || "/",
+        clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
+        authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY || '',
+        redirectUri: process.env.NEXT_PUBLIC_REDIRECT_URI || `${origin}/landing`,
+        postLogoutRedirectUri: process.env.NEXT_PUBLIC_POST_LOGOUT_REDIRECT_URI || origin || '/',
         navigateToLoginRequestUrl: true,
     },
     cache: {
@@ -22,14 +24,16 @@ export const msalConfig = {
                 }
                 switch (level) {
                     case LogLevel.Error:
-                        logger.error(message);
+                        logger.error('[MSAL]', message);
                         return;
                     case LogLevel.Info:
+                        logger.log('[MSAL]', message);
                         return;
                     case LogLevel.Verbose:
+                        logger.log('[MSAL VERBOSE]', message);
                         return;
                     case LogLevel.Warning:
-                        console.warn(message);
+                        console.warn('[MSAL]', message);
                         return;
                     default:
                         return;

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -61,8 +61,13 @@ export async function fetchWithAuth<T = any>(
     logger.error(`[apiClient] Silent token acquisition failed for ${apiUrl}:`, error);
     if (error instanceof InteractionRequiredAuthError) {
       logger.log(`[apiClient] Interaction required for ${apiUrl}. Depending on app flow, redirect/popup should be invoked.`);
-      // msalInstance.acquireTokenRedirect(request); // Or acquireTokenPopup
-      // For now, let API call fail to indicate an issue with interaction handling.
+      try {
+        tokenResponse = await msalInstance.acquireTokenSilent(request);
+      } catch (e) {
+        logger.error('[apiClient] Silent retry failed, redirecting user');
+        msalInstance.acquireTokenRedirect(request).catch(err => logger.error('Redirect for token failed', err));
+        throw e;
+      }
     }
     // If acquireTokenSilent fails for other reasons, tokenResponse will be undefined and handled below.
   }
@@ -94,10 +99,25 @@ export async function fetchWithAuth<T = any>(
   const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || ''; // e.g., http://localhost:3000
 
   try {
-    const response = await fetch(`${apiBaseUrl}${apiUrl}`, {
+    let response = await fetch(`${apiBaseUrl}${apiUrl}`, {
       ...requestOptions,
       headers,
     });
+
+    if (response.status === 401) {
+      logger.warn(`[apiClient] 401 for ${apiUrl}. Attempting token refresh.`);
+      try {
+        tokenResponse = await msalInstance.acquireTokenSilent(request);
+        headers.set('Authorization', `Bearer ${tokenResponse.accessToken}`);
+        response = await fetch(`${apiBaseUrl}${apiUrl}`, {
+          ...requestOptions,
+          headers,
+        });
+      } catch (refreshError) {
+        logger.error('[apiClient] Token refresh failed', refreshError);
+        throw refreshError;
+      }
+    }
 
     if (apiUrl.includes('activeMatrixCheck')) {
       logger.log(`[apiClient] Response status for activeMatrixCheck (${apiUrl}): ${response.status}`);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,31 +8,36 @@ import type { AppProps } from 'next/app';
 import 'react-toastify/dist/ReactToastify.css';
 import { ToastContainer } from 'react-toastify';
 import AppLayout from '@/components/layout/AppLayout';
+import RouteGuard from '@/components/RouteGuard';
+import MSALDebug from '@/components/MSALDebug';
 
 const msalInstance = new PublicClientApplication(msalConfig);
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <MsalProvider instance={msalInstance}>
-      <SelectedEmployeeProvider>
-        <FuncionarioProvider>
-          <AppLayout>
-            <Component {...pageProps} />
-          </AppLayout>
-          <ToastContainer
-            position="top-right"
-            autoClose={5000}
-            hideProgressBar={false}
-            newestOnTop={false}
-            closeOnClick
-            rtl={false}
-            pauseOnFocusLoss
-            draggable
-            pauseOnHover
-            theme="light"
-          />
-        </FuncionarioProvider>
-      </SelectedEmployeeProvider>
+      <RouteGuard>
+        <SelectedEmployeeProvider>
+          <FuncionarioProvider>
+            <AppLayout>
+              <Component {...pageProps} />
+              <MSALDebug />
+            </AppLayout>
+            <ToastContainer
+              position="top-right"
+              autoClose={5000}
+              hideProgressBar={false}
+              newestOnTop={false}
+              closeOnClick
+              rtl={false}
+              pauseOnFocusLoss
+              draggable
+              pauseOnHover
+              theme="light"
+            />
+          </FuncionarioProvider>
+        </SelectedEmployeeProvider>
+      </RouteGuard>
     </MsalProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add helper script to create `.env.local`
- improve MSAL config with dynamic URLs and better logging
- add MSAL debug component for local development
- implement simple route guard
- refresh token on 401 in API client
- expose debug and guard in `_app`
- mention setup script in README and use logger in `RouteGuard`

## Testing
- `npm install --silent`
- `npm run lint` *(fails: Parsing error in syncEmployees.js)*

------
https://chatgpt.com/codex/tasks/task_e_686691d7702883329513c070d657c117